### PR TITLE
move shared flags to the cmdutil package

### DIFF
--- a/pkg/cmd/config/edit.go
+++ b/pkg/cmd/config/edit.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/apex/log"
 	"github.com/martinohmann/kickoff/pkg/boilerplate"
+	"github.com/martinohmann/kickoff/pkg/cmdutil"
 	"github.com/martinohmann/kickoff/pkg/config"
 	"github.com/martinohmann/kickoff/pkg/file"
 	"github.com/spf13/cobra"
@@ -37,7 +38,7 @@ func NewEditCmd() *cobra.Command {
 		},
 	}
 
-	cmd.Flags().StringVar(&o.ConfigPath, "config", o.ConfigPath, "Path to config file")
+	cmdutil.AddConfigFlag(cmd, &o.ConfigPath)
 
 	return cmd
 }

--- a/pkg/cmd/config/show_test.go
+++ b/pkg/cmd/config/show_test.go
@@ -2,25 +2,21 @@ package config
 
 import (
 	"bytes"
-	"errors"
-	"reflect"
 	"testing"
 
 	"github.com/martinohmann/kickoff/pkg/cli"
+	"github.com/martinohmann/kickoff/pkg/cmdutil"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
-func TestShowCmd_Execute_NonexistantConfig(t *testing.T) {
+func TestShowCmd_Execute_NonexistentConfig(t *testing.T) {
 	streams := cli.NewTestIOStreams()
 	cmd := NewShowCmd(streams)
 	cmd.SetArgs([]string{"--config", "nonexistent"})
 
-	expectedErr := errors.New(`file "nonexistent" does not exist`)
-
 	err := cmd.Execute()
-	if !reflect.DeepEqual(expectedErr, err) {
-		t.Fatalf("expected error %v, got %v", expectedErr, err)
-	}
+	require.Error(t, err)
 }
 
 func TestShowCmd_Execute_InvalidOutput(t *testing.T) {
@@ -29,8 +25,8 @@ func TestShowCmd_Execute_InvalidOutput(t *testing.T) {
 	cmd.SetArgs([]string{"--output", "enterprise-xml"})
 
 	err := cmd.Execute()
-	if err != ErrInvalidOutputFormat {
-		t.Fatalf("expected error %v, got %v", ErrInvalidOutputFormat, err)
+	if err != cmdutil.ErrInvalidOutputFormat {
+		t.Fatalf("expected error %v, got %v", cmdutil.ErrInvalidOutputFormat, err)
 	}
 }
 

--- a/pkg/cmd/project/create.go
+++ b/pkg/cmd/project/create.go
@@ -6,17 +6,16 @@ import (
 	"path/filepath"
 
 	"github.com/apex/log"
-	"github.com/martinohmann/kickoff/pkg/config"
+	"github.com/martinohmann/kickoff/pkg/cmdutil"
 	"github.com/martinohmann/kickoff/pkg/file"
 	"github.com/martinohmann/kickoff/pkg/project"
 	"github.com/martinohmann/kickoff/pkg/skeleton"
-	"github.com/martinohmann/kickoff/pkg/template"
 	"github.com/spf13/cobra"
 	"helm.sh/helm/pkg/strvals"
 )
 
 func NewCreateCmd() *cobra.Command {
-	o := NewCreateOptions()
+	o := &CreateOptions{}
 
 	cmd := &cobra.Command{
 		Use:   "create <skeleton-name> <output-dir>",
@@ -36,34 +35,27 @@ func NewCreateCmd() *cobra.Command {
 	}
 
 	o.AddFlags(cmd)
+	o.ConfigFlags.AddFlags(cmd)
+
+	cmdutil.AddRepositoryURLFlag(cmd, &o.Skeletons.RepositoryURL)
+	cmdutil.AddForceFlag(cmd, &o.Force)
 
 	return cmd
 }
 
 type CreateOptions struct {
-	ConfigPath string
-	OutputDir  string
-	Skeleton   string
-	DryRun     bool
-	Force      bool
+	cmdutil.ConfigFlags
 
-	config.Config
+	OutputDir string
+	Skeleton  string
+	DryRun    bool
+	Force     bool
 
 	rawValues []string
 }
 
-func NewCreateOptions() *CreateOptions {
-	return &CreateOptions{
-		Config: config.Config{
-			Values: template.Values{},
-		},
-	}
-}
-
 func (o *CreateOptions) AddFlags(cmd *cobra.Command) {
 	cmd.Flags().BoolVar(&o.DryRun, "dry-run", o.DryRun, "Only print what would be done")
-	cmd.Flags().BoolVar(&o.Force, "force", o.Force, "Forces overwrite of existing output directory")
-	cmd.Flags().StringVar(&o.ConfigPath, "config", o.ConfigPath, fmt.Sprintf("Path to config file (defaults to %q if the file exists)", config.DefaultConfigPath))
 
 	cmd.Flags().StringVar(&o.License, "license", o.License, "License to use for the project. If set this will automatically populate the LICENSE file")
 
@@ -74,8 +66,6 @@ func (o *CreateOptions) AddFlags(cmd *cobra.Command) {
 	cmd.Flags().StringVar(&o.Git.User, "git-user", o.Git.User, "Git repository user")
 	cmd.Flags().StringVar(&o.Git.RepoName, "git-repo-name", o.Git.RepoName, "Git repository name for the project (defaults to the project name)")
 	cmd.Flags().StringVar(&o.Git.Host, "git-host", o.Git.Host, "Git repository host")
-
-	cmd.Flags().StringVar(&o.Skeletons.RepositoryURL, "repository-url", o.Skeletons.RepositoryURL, fmt.Sprintf("URL of the skeleton repository. Can be a local path or remote git repository. (defaults to %q if the directory exists)", config.DefaultSkeletonRepositoryURL))
 
 	cmd.Flags().StringArrayVar(&o.rawValues, "set", o.rawValues, "Set custom values of the form key1=value1,key2=value2,deeply.nested.key3=value that are then made available to .skel templates")
 }
@@ -90,20 +80,12 @@ func (o *CreateOptions) Complete(args []string) (err error) {
 		}
 	}
 
-	if o.ConfigPath == "" && file.Exists(config.DefaultConfigPath) {
-		o.ConfigPath = config.DefaultConfigPath
-	}
-
-	if o.ConfigPath != "" {
-		log.WithField("path", o.ConfigPath).Debugf("loading config file")
-
-		err = o.Config.MergeFromFile(o.ConfigPath)
-		if err != nil {
-			return err
-		}
-	}
-
 	defaultProjectName := filepath.Base(o.OutputDir)
+
+	err = o.ConfigFlags.Complete(defaultProjectName)
+	if err != nil {
+		return err
+	}
 
 	o.ApplyDefaults(defaultProjectName)
 
@@ -121,19 +103,19 @@ func (o *CreateOptions) Complete(args []string) (err error) {
 
 func (o *CreateOptions) Validate() error {
 	if file.Exists(o.OutputDir) && !o.Force {
-		return fmt.Errorf("output-dir %s already exists, add --force to overwrite", o.OutputDir)
+		return fmt.Errorf("output dir %s already exists, add --force to overwrite", o.OutputDir)
 	}
 
 	if o.OutputDir == "" {
-		return errors.New("output-dir must not be an empty string")
+		return cmdutil.ErrEmptyOutputDir
 	}
 
 	if o.Skeleton == "" {
-		return fmt.Errorf("skeleton name must be provided")
+		return cmdutil.ErrEmptySkeletonName
 	}
 
 	if o.Git.User == "" {
-		return fmt.Errorf("--git-user needs to be set as it could not be inferred")
+		return errors.New("--git-user needs to be set as it could not be inferred")
 	}
 
 	return nil

--- a/pkg/cmd/skeleton/init.go
+++ b/pkg/cmd/skeleton/init.go
@@ -1,7 +1,6 @@
 package skeleton
 
 import (
-	"errors"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -9,13 +8,10 @@ import (
 
 	"github.com/apex/log"
 	"github.com/martinohmann/kickoff/pkg/boilerplate"
+	"github.com/martinohmann/kickoff/pkg/cmdutil"
 	"github.com/martinohmann/kickoff/pkg/config"
 	"github.com/martinohmann/kickoff/pkg/file"
 	"github.com/spf13/cobra"
-)
-
-var (
-	ErrEmptyOutputDir = errors.New("output-dir must not be an empty string")
 )
 
 func NewInitCmd() *cobra.Command {
@@ -39,7 +35,7 @@ func NewInitCmd() *cobra.Command {
 		},
 	}
 
-	cmd.Flags().BoolVar(&o.Force, "force", o.Force, "Forces overwrite of existing output directory")
+	cmdutil.AddForceFlag(cmd, &o.Force)
 
 	return cmd
 }
@@ -62,11 +58,11 @@ func (o *InitOptions) Complete(args []string) (err error) {
 
 func (o *InitOptions) Validate() error {
 	if file.Exists(o.OutputDir) && !o.Force {
-		return fmt.Errorf("output-dir %s already exists, add --force to overwrite", o.OutputDir)
+		return fmt.Errorf("output dir %s already exists, add --force to overwrite", o.OutputDir)
 	}
 
 	if o.OutputDir == "" {
-		return ErrEmptyOutputDir
+		return cmdutil.ErrEmptyOutputDir
 	}
 
 	return nil

--- a/pkg/cmd/skeleton/init_test.go
+++ b/pkg/cmd/skeleton/init_test.go
@@ -7,6 +7,8 @@ import (
 	"path/filepath"
 	"reflect"
 	"testing"
+
+	"github.com/martinohmann/kickoff/pkg/cmdutil"
 )
 
 func TestInitCmd_Execute_EmptyOutputDir(t *testing.T) {
@@ -14,8 +16,8 @@ func TestInitCmd_Execute_EmptyOutputDir(t *testing.T) {
 	cmd.SetArgs([]string{""})
 
 	err := cmd.Execute()
-	if err != ErrEmptyOutputDir {
-		t.Fatalf("expected error %v, got %v", ErrEmptyOutputDir, err)
+	if err != cmdutil.ErrEmptyOutputDir {
+		t.Fatalf("expected error %v, got %v", cmdutil.ErrEmptyOutputDir, err)
 	}
 }
 
@@ -28,7 +30,7 @@ func TestInitCmd_Execute_DirExists(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	expectedErr := fmt.Errorf("output-dir %s already exists, add --force to overwrite", dir)
+	expectedErr := fmt.Errorf("output dir %s already exists, add --force to overwrite", dir)
 
 	err = cmd.Execute()
 	if !reflect.DeepEqual(expectedErr, err) {

--- a/pkg/cmd/skeleton/list.go
+++ b/pkg/cmd/skeleton/list.go
@@ -1,10 +1,8 @@
 package skeleton
 
 import (
-	"fmt"
-
 	"github.com/martinohmann/kickoff/pkg/cli"
-	"github.com/martinohmann/kickoff/pkg/config"
+	"github.com/martinohmann/kickoff/pkg/cmdutil"
 	"github.com/martinohmann/kickoff/pkg/skeleton"
 	"github.com/spf13/cobra"
 )
@@ -19,24 +17,27 @@ func NewListCmd(streams cli.IOStreams) *cobra.Command {
 		Long:    "Lists all skeletons available in the repository",
 		Args:    cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			o.ApplyDefaults()
+			if err := o.Complete(""); err != nil {
+				return err
+			}
 
 			return o.Run()
 		},
 	}
 
-	cmd.Flags().StringVar(&o.RepositoryURL, "repository-url", o.RepositoryURL, fmt.Sprintf("URL of the skeleton repository. Can be a local path or remote git repository. (defaults to %q if the directory exists)", config.DefaultSkeletonRepositoryURL))
+	o.ConfigFlags.AddFlags(cmd)
+	cmdutil.AddRepositoryURLFlag(cmd, &o.Skeletons.RepositoryURL)
 
 	return cmd
 }
 
 type ListOptions struct {
 	cli.IOStreams
-	config.Skeletons
+	cmdutil.ConfigFlags
 }
 
 func (o *ListOptions) Run() error {
-	repo, err := skeleton.OpenRepository(o.RepositoryURL)
+	repo, err := skeleton.OpenRepository(o.Skeletons.RepositoryURL)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/version.go
+++ b/pkg/cmd/version.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/ghodss/yaml"
 	"github.com/martinohmann/kickoff/pkg/cli"
+	"github.com/martinohmann/kickoff/pkg/cmdutil"
 	"github.com/martinohmann/kickoff/pkg/version"
 	"github.com/spf13/cobra"
 )
@@ -15,10 +16,6 @@ var (
 	// ErrIllegalVersionFlagCombination is returned if mutual exclusive version
 	// format flags are set.
 	ErrIllegalVersionFlagCombination = errors.New("--short and --output can't be used together")
-
-	// ErrInvalidOutputFormat is returned if the output format flag contains an
-	// invalid value.
-	ErrInvalidOutputFormat = errors.New("--output must be 'yaml' or 'json'")
 )
 
 func NewVersionCmd(streams cli.IOStreams) *cobra.Command {
@@ -38,15 +35,17 @@ func NewVersionCmd(streams cli.IOStreams) *cobra.Command {
 	}
 
 	cmd.Flags().BoolVar(&o.Short, "short", false, "Display short version")
-	cmd.Flags().StringVar(&o.Output, "output", o.Output, "Output format")
+
+	o.OutputFlags.AddFlags(cmd)
 
 	return cmd
 }
 
 type VersionOptions struct {
 	cli.IOStreams
-	Short  bool
-	Output string
+	cmdutil.OutputFlags
+
+	Short bool
 }
 
 func (o *VersionOptions) Validate() error {
@@ -54,11 +53,7 @@ func (o *VersionOptions) Validate() error {
 		return ErrIllegalVersionFlagCombination
 	}
 
-	if o.Output != "" && o.Output != "yaml" && o.Output != "json" {
-		return ErrInvalidOutputFormat
-	}
-
-	return nil
+	return o.OutputFlags.Validate()
 }
 
 func (o *VersionOptions) Run() error {

--- a/pkg/cmdutil/config_flags.go
+++ b/pkg/cmdutil/config_flags.go
@@ -1,0 +1,49 @@
+package cmdutil
+
+import (
+	"github.com/apex/log"
+	"github.com/martinohmann/kickoff/pkg/config"
+	"github.com/martinohmann/kickoff/pkg/file"
+	"github.com/spf13/cobra"
+)
+
+// ConfigFlags provide a flag for configuring the path to the kickoff config
+// file. Can be used to automatically populate the kickoff config with defaults
+// and optionally override them if the user passed a different config path via
+// the CLI flag.
+type ConfigFlags struct {
+	config.Config
+
+	configPath string
+}
+
+// AddFlags adds flags for configuring the config file location to cmd.
+func (f *ConfigFlags) AddFlags(cmd *cobra.Command) {
+	AddConfigFlag(cmd, &f.configPath)
+}
+
+// Complete completes the embedded kickoff configuration using the provided
+// defaultProjectName. It will load the config file from the path provided by
+// the user and merge it into the configuration and apply configuration
+// defaults to unset fields. Returns an error if the config file does not
+// exist, could not be read or contains invalid configuration. If the user did
+// not provide any config file path, the default config file will be loaded
+// instead, if it exists.
+func (f *ConfigFlags) Complete(defaultProjectName string) (err error) {
+	if f.configPath == "" && file.Exists(config.DefaultConfigPath) {
+		f.configPath = config.DefaultConfigPath
+	}
+
+	if f.configPath != "" {
+		log.WithField("path", f.configPath).Debugf("loading config file")
+
+		err = f.Config.MergeFromFile(f.configPath)
+		if err != nil {
+			return err
+		}
+	}
+
+	f.ApplyDefaults(defaultProjectName)
+
+	return nil
+}

--- a/pkg/cmdutil/errors.go
+++ b/pkg/cmdutil/errors.go
@@ -1,0 +1,17 @@
+package cmdutil
+
+import "errors"
+
+var (
+	// ErrEmptyOutputDir is returned if the user passed an empty string as the
+	// output directory.
+	ErrEmptyOutputDir = errors.New("output dir must not be an empty string")
+
+	// ErrEmptySkeletonName is returned if the user passed an empty string as
+	// skeleton name.
+	ErrEmptySkeletonName = errors.New("skeleton name must be provided")
+
+	// ErrInvalidOutputFormat is returned if the output format flag contains an
+	// invalid value.
+	ErrInvalidOutputFormat = errors.New("--output must be 'yaml' or 'json'")
+)

--- a/pkg/cmdutil/flags.go
+++ b/pkg/cmdutil/flags.go
@@ -1,0 +1,24 @@
+package cmdutil
+
+import (
+	"fmt"
+
+	"github.com/martinohmann/kickoff/pkg/config"
+	"github.com/spf13/cobra"
+)
+
+// AddConfigFlag adds the --config flag to cmd and binds it to val.
+func AddConfigFlag(cmd *cobra.Command, val *string) {
+	cmd.Flags().StringVar(val, "config", *val, fmt.Sprintf("Path to config file (defaults to %q if the file exists)", config.DefaultConfigPath))
+}
+
+// AddRepositoryURLFlag adds the --repository-url flag to cmd and binds it to
+// val.
+func AddRepositoryURLFlag(cmd *cobra.Command, val *string) {
+	cmd.Flags().StringVar(val, "repository-url", *val, fmt.Sprintf("URL of the skeleton repository. Can be a local path or remote git repository. (defaults to %q if the directory exists)", config.DefaultSkeletonRepositoryURL))
+}
+
+// AddForceFlag adds the --force flag to cmd and binds it to val.
+func AddForceFlag(cmd *cobra.Command, val *bool) {
+	cmd.Flags().BoolVar(val, "force", *val, "Forces overwrite of existing output directory")
+}

--- a/pkg/cmdutil/output_flags.go
+++ b/pkg/cmdutil/output_flags.go
@@ -1,0 +1,25 @@
+package cmdutil
+
+import (
+	"github.com/spf13/cobra"
+)
+
+// OutputFlags manage and validate flags related to output format.
+type OutputFlags struct {
+	Output string
+}
+
+// AddFlags adds flags for configuring output format to cmd.
+func (f *OutputFlags) AddFlags(cmd *cobra.Command) {
+	cmd.Flags().StringVar(&f.Output, "output", f.Output, "Output format")
+}
+
+// Validate validates the output format and returns an error if the user
+// provided an invalid value.
+func (f *OutputFlags) Validate() error {
+	if f.Output != "" && f.Output != "yaml" && f.Output != "json" {
+		return ErrInvalidOutputFormat
+	}
+
+	return nil
+}


### PR DESCRIPTION
This avoids duplication and makes it easier to introduce global changes
to the CLI.