### PR TITLE
add support for gitignore templates

### DIFF
--- a/_examples/config.yaml
+++ b/_examples/config.yaml
@@ -38,6 +38,27 @@ project:
 #
 license: ""
 
+# Gitignore configuration
+# =======================
+#
+# A .gitignore file will be automatically generated if gitignore templates are
+# specified. All gitignore templates available via the gitignore.io API are
+# supported.
+#
+# Check out the 'kickoff gitignore list' for a list a available templates.
+#
+# Example:
+# --------
+#
+#   gitignore: go
+#
+# Multiple gitignore templates:
+# -----------------------------
+#
+#   gitignore: go,helm,hugo
+#
+gitignore: ""
+
 # Git configuration
 # =================
 #

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/martinohmann/kickoff
 go 1.13
 
 require (
+	github.com/MakeNowJust/heredoc v1.0.0
 	github.com/Masterminds/semver v1.5.0 // indirect
 	github.com/Masterminds/sprig v2.22.0+incompatible
 	github.com/Masterminds/sprig/v3 v3.0.2

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,6 @@
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
+github.com/MakeNowJust/heredoc v1.0.0 h1:cXCdzVdstXyiTqTvfqk9SDHpKNjxuom+DOlyEeQ4pzQ=
+github.com/MakeNowJust/heredoc v1.0.0/go.mod h1:mG5amYoWBHf8vpLOuehzbGGw0EHxpZZ6lCpQ4fNJ8LE=
 github.com/Masterminds/goutils v1.1.0 h1:zukEsf/1JZwCMgHiK3GZftabmxiCw4apj3a28RPBiVg=
 github.com/Masterminds/goutils v1.1.0/go.mod h1:8cTjp+g8YejhMuvIA5y2vz3BpJxksy863GQaJW2MFNU=
 github.com/Masterminds/semver v1.5.0 h1:H65muMkzWKEuNDnfl9d70GUjFniHKHRbFPGBuZ3QEww=

--- a/pkg/boilerplate/defaults.go
+++ b/pkg/boilerplate/defaults.go
@@ -61,6 +61,27 @@ project:
 #
 license: ""
 
+# Gitignore configuration
+# =======================
+#
+# A .gitignore file will be automatically generated if gitignore templates are
+# specified. All gitignore templates available via the gitignore.io API are
+# supported.
+#
+# Check out the 'kickoff gitignore list' for a list a available templates.
+#
+# Example:
+# --------
+#
+#   gitignore: go
+#
+# Multiple gitignore templates:
+# -----------------------------
+#
+#   gitignore: go,helm,hugo
+#
+gitignore: ""
+
 # Git configuration
 # =================
 #

--- a/pkg/cmd/gitignore.go
+++ b/pkg/cmd/gitignore.go
@@ -1,0 +1,20 @@
+package cmd
+
+import (
+	"github.com/martinohmann/kickoff/pkg/cli"
+	"github.com/martinohmann/kickoff/pkg/cmd/gitignore"
+	"github.com/spf13/cobra"
+)
+
+func NewGitignoreCmd(streams cli.IOStreams) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "gitignore",
+		Aliases: []string{"gi", "gitignores"},
+		Short:   "Inspect gitignore templates",
+	}
+
+	cmd.AddCommand(gitignore.NewListCmd(streams))
+	cmd.AddCommand(gitignore.NewShowCmd(streams))
+
+	return cmd
+}

--- a/pkg/cmd/gitignore/list.go
+++ b/pkg/cmd/gitignore/list.go
@@ -1,0 +1,40 @@
+package gitignore
+
+import (
+	"github.com/martinohmann/kickoff/pkg/cli"
+	"github.com/martinohmann/kickoff/pkg/cmdutil"
+	"github.com/martinohmann/kickoff/pkg/gitignore"
+	"github.com/spf13/cobra"
+)
+
+func NewListCmd(streams cli.IOStreams) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "list",
+		Aliases: []string{"ls"},
+		Short:   "List available gitignores",
+		Long: cmdutil.LongDesc(`
+			Lists gitignores available via the gitignore.io API.
+
+			Check out https://www.gitignore.io for more information about .gitignore templates.`),
+		Args: cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			gitignores, err := gitignore.List()
+			if err != nil {
+				return err
+			}
+
+			tw := cli.NewTableWriter(streams.Out)
+			tw.SetHeader("Name")
+
+			for _, gitignore := range gitignores {
+				tw.Append(gitignore)
+			}
+
+			tw.Render()
+
+			return nil
+		},
+	}
+
+	return cmd
+}

--- a/pkg/cmd/gitignore/show.go
+++ b/pkg/cmd/gitignore/show.go
@@ -1,0 +1,40 @@
+package gitignore
+
+import (
+	"fmt"
+
+	"github.com/martinohmann/kickoff/pkg/cli"
+	"github.com/martinohmann/kickoff/pkg/cmdutil"
+	"github.com/martinohmann/kickoff/pkg/gitignore"
+	"github.com/spf13/cobra"
+)
+
+func NewShowCmd(streams cli.IOStreams) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "show <name>",
+		Short: "Fetch a gitignore template",
+		Long: cmdutil.LongDesc(`
+			Fetches a gitignore template via the gitignore.io API.
+
+			Check out https://www.gitignore.io for more information about .gitignore templates.`),
+		Example: cmdutil.Examples(`
+			# Fetch a single template
+			kickoff gitignore show go
+
+			# Fetch multiple concatenated templates
+			kickoff gitignore show go,helm,hugo`),
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			gitignore, err := gitignore.Get(args[0])
+			if err != nil {
+				return err
+			}
+
+			fmt.Fprintln(streams.Out, gitignore)
+
+			return nil
+		},
+	}
+
+	return cmd
+}

--- a/pkg/cmd/license.go
+++ b/pkg/cmd/license.go
@@ -10,7 +10,7 @@ func NewLicenseCmd(streams cli.IOStreams) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "license",
 		Aliases: []string{"lic", "licenses"},
-		Short:   "Manage licenses",
+		Short:   "Inspect open source licenses",
 	}
 
 	cmd.AddCommand(license.NewListCmd(streams))

--- a/pkg/cmd/project/create.go
+++ b/pkg/cmd/project/create.go
@@ -57,6 +57,7 @@ func (o *CreateOptions) AddFlags(cmd *cobra.Command) {
 	cmd.Flags().BoolVar(&o.DryRun, "dry-run", o.DryRun, "Only print what would be done")
 
 	cmd.Flags().StringVar(&o.License, "license", o.License, "License to use for the project. If set this will automatically populate the LICENSE file")
+	cmd.Flags().StringVar(&o.Gitignore, "gitignore", o.Gitignore, "Comma-separated list of gitignore template to use for the project. If set this will automatically populate the .gitignore file")
 
 	cmd.Flags().StringVar(&o.Project.Name, "project-name", o.Project.Name, "Name of the project. Will be inferred from the output dir if not explicitly set")
 	cmd.Flags().StringVar(&o.Project.Author, "project-author", o.Project.Author, "Project author's fullname")

--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -23,6 +23,7 @@ func NewRootCmd(streams cli.IOStreams) *cobra.Command {
 	cmd.PersistentFlags().BoolVar(&verbose, "verbose", verbose, "Enable verbose log output")
 
 	cmd.AddCommand(NewConfigCmd(streams))
+	cmd.AddCommand(NewGitignoreCmd(streams))
 	cmd.AddCommand(NewProjectCmd())
 	cmd.AddCommand(NewLicenseCmd(streams))
 	cmd.AddCommand(NewRepositoryCmd(streams))

--- a/pkg/cmd/skeleton/list_test.go
+++ b/pkg/cmd/skeleton/list_test.go
@@ -12,7 +12,7 @@ import (
 func TestListCmd_Execute(t *testing.T) {
 	streams := cli.NewTestIOStreams()
 	cmd := NewListCmd(streams)
-	cmd.SetArgs([]string{"--repositories", "default=../../skeleton/testdata/local-dir"})
+	cmd.SetArgs([]string{"--config", "../../config/testdata/empty-config.yaml", "--repositories", "default=../../skeleton/testdata/local-dir"})
 
 	err := cmd.Execute()
 	require.NoError(t, err)

--- a/pkg/cmd/skeleton/show_test.go
+++ b/pkg/cmd/skeleton/show_test.go
@@ -12,7 +12,7 @@ import (
 func TestShowCmd_Execute_NonexistantRepository(t *testing.T) {
 	streams := cli.NewTestIOStreams()
 	cmd := NewShowCmd(streams)
-	cmd.SetArgs([]string{"myskeleton", "--repositories", "default=nonexistent"})
+	cmd.SetArgs([]string{"myskeleton", "--config", "../../config/testdata/empty-config.yaml", "--repositories", "default=nonexistent"})
 
 	err := cmd.Execute()
 	require.Error(t, err)
@@ -21,7 +21,7 @@ func TestShowCmd_Execute_NonexistantRepository(t *testing.T) {
 func TestShowCmd_Execute_InvalidOutput(t *testing.T) {
 	streams := cli.NewTestIOStreams()
 	cmd := NewShowCmd(streams)
-	cmd.SetArgs([]string{"myskeleton", "--output", "enterprise-xml"})
+	cmd.SetArgs([]string{"myskeleton", "--config", "../../config/testdata/empty-config.yaml", "--output", "enterprise-xml"})
 
 	err := cmd.Execute()
 	require.Error(t, err)
@@ -30,7 +30,7 @@ func TestShowCmd_Execute_InvalidOutput(t *testing.T) {
 func TestShowCmd_Execute(t *testing.T) {
 	streams := cli.NewTestIOStreams()
 	cmd := NewShowCmd(streams)
-	cmd.SetArgs([]string{"a-skeleton", "--repositories", "default=../../skeleton/testdata/local-dir"})
+	cmd.SetArgs([]string{"a-skeleton", "--config", "../../config/testdata/empty-config.yaml", "--repositories", "default=../../skeleton/testdata/local-dir"})
 
 	err := cmd.Execute()
 	require.NoError(t, err)

--- a/pkg/cmdutil/command_docs.go
+++ b/pkg/cmdutil/command_docs.go
@@ -1,0 +1,32 @@
+package cmdutil
+
+import (
+	"strings"
+
+	"github.com/MakeNowJust/heredoc"
+)
+
+// LongDesc formats the long description for a *cobra.Command.
+func LongDesc(s string) string {
+	return trim(heredoc.Doc(s))
+}
+
+// Examples formats examples for a *cobra.Command. Each line is indented by 2
+// spaces so that it aligns nicely with usage and flags.
+func Examples(s string) string {
+	return indent(trim(s), "  ")
+}
+
+func indent(s, indent string) string {
+	lines := strings.Split(s, "\n")
+
+	for i, line := range lines {
+		lines[i] = indent + trim(line)
+	}
+
+	return strings.Join(lines, "\n")
+}
+
+func trim(s string) string {
+	return strings.TrimSpace(s)
+}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -36,9 +36,13 @@ const (
 	// that repository related urls can be rendered in files like READMEs.
 	DefaultGitHost = "github.com"
 
-	// The DefaultLicense is "none", which means that no license file will be
-	// generated for a new project.
-	DefaultLicense = "none"
+	// NoLicense means that no license file will be generated for a new
+	// project.
+	NoLicense = "none"
+
+	// NoGitignore means that no .gitignore file will be generated for a new
+	// project.
+	NoGitignore = "none"
 
 	// SkeletonConfigFile is the name of the skeleton's config file.
 	SkeletonConfigFile = ".kickoff.yaml"
@@ -47,6 +51,7 @@ const (
 // Config is the type for user-defined configuration.
 type Config struct {
 	License      string            `json:"license"`
+	Gitignore    string            `json:"gitignore"`
 	Project      Project           `json:"project"`
 	Git          Git               `json:"git"`
 	Repositories map[string]string `json:"repositories"`
@@ -58,7 +63,11 @@ type Config struct {
 // (if they are unset).
 func (c *Config) ApplyDefaults(defaultProjectName string) {
 	if c.License == "" {
-		c.License = DefaultLicense
+		c.License = NoLicense
+	}
+
+	if c.Gitignore == "" {
+		c.Gitignore = NoGitignore
 	}
 
 	if c.Repositories == nil {
@@ -90,7 +99,14 @@ func (c *Config) MergeFromFile(path string) error {
 // config. If true, the project creator will write the text of the provided
 // license into the LICENSE file in the project's output directory.
 func (c *Config) HasLicense() bool {
-	return c.License != "" && c.License != "none"
+	return c.License != "" && c.License != NoLicense
+}
+
+// HasGitignore returns true if a gitignore template is specified in the
+// config. If true, the project creator will write the gitignore template into
+// the .gitignore file in the project's output directory.
+func (c *Config) HasGitignore() bool {
+	return c.Gitignore != "" && c.Gitignore != NoGitignore
 }
 
 // Project contains project specific configuration like author, email address

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -22,7 +22,8 @@ func TestConfig_ApplyDefaults(t *testing.T) {
 	config.ApplyDefaults("myproject")
 
 	expected := Config{
-		License: DefaultLicense,
+		License:   NoLicense,
+		Gitignore: NoGitignore,
 		Project: Project{
 			Name:   "myproject",
 			Author: "John Doe",

--- a/pkg/gitignore/gitignore.go
+++ b/pkg/gitignore/gitignore.go
@@ -1,0 +1,73 @@
+package gitignore
+
+import (
+	"bufio"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"strings"
+
+	"github.com/apex/log"
+)
+
+var (
+	// apiBaseURL is a variable and not a constant so it can be replaced in
+	// tests.
+	apiBaseURL = "https://gitignore.io/api"
+
+	// ErrNotFound is returned if a gitignore template could not be found.
+	ErrNotFound = errors.New("gitignore not found")
+)
+
+// Get fetches the gitignore template for query from gitignore.io. The query
+// can be a comma-separated list of gitignore templates (e.g. "go,python")
+// which are combined into a single gitignore template. Will return an error if
+// the http connection fails or if the response status code is not 200. Will
+// return ErrNotFound if any of the requested gitignore templates cannot be
+// found.
+func Get(query string) (string, error) {
+	log.WithField("query", query).Debug("fetching template from gitignore.io")
+
+	resp, err := http.Get(fmt.Sprintf("%s/%s", apiBaseURL, query))
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == 404 {
+		return "", ErrNotFound
+	} else if resp.StatusCode != 200 {
+		return "", fmt.Errorf("gitignore.io returned status code %d while fetching gitignore template", resp.StatusCode)
+	}
+
+	body, err := ioutil.ReadAll(resp.Body)
+
+	return strings.TrimSpace(string(body)), err
+}
+
+// List obtains a list of available gitignore templates from gitignore.io. Will
+// return an error if the http connection fails or the response status code is
+// not 200.
+func List() ([]string, error) {
+	log.Debug("fetching template list from gitignore.io")
+
+	resp, err := http.Get(fmt.Sprintf("%s/list", apiBaseURL))
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != 200 {
+		return nil, fmt.Errorf("gitignore.io returned status code %d while listing gitignore templates", resp.StatusCode)
+	}
+
+	gitignores := make([]string, 0)
+
+	scanner := bufio.NewScanner(resp.Body)
+	for scanner.Scan() {
+		gitignores = append(gitignores, strings.Split(scanner.Text(), ",")...)
+	}
+
+	return gitignores, nil
+}

--- a/pkg/gitignore/gitignore_test.go
+++ b/pkg/gitignore/gitignore_test.go
@@ -1,0 +1,170 @@
+package gitignore
+
+import (
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestList(t *testing.T) {
+	var tests = []struct {
+		name        string
+		handler     func(t *testing.T) http.HandlerFunc
+		expected    []string
+		expectError bool
+		expectedErr error
+	}{
+		{
+			name:     "returns a list of gitignores",
+			expected: []string{"foo", "bar", "baz", "qux"},
+			handler: func(t *testing.T) http.HandlerFunc {
+				return func(w http.ResponseWriter, r *http.Request) {
+					if r.RequestURI != "/list" {
+						t.Fatalf("unexpected request URI: %s", r.RequestURI)
+					}
+
+					_, err := w.Write([]byte("foo,bar\nbaz\nqux\n"))
+					if err != nil {
+						t.Fatal(err)
+					}
+
+					w.WriteHeader(200)
+				}
+			},
+		},
+		{
+			name:        "returns error on non-200 status codes",
+			expectError: true,
+			expectedErr: errors.New("gitignore.io returned status code 500 while listing gitignore templates"),
+			handler: func(t *testing.T) http.HandlerFunc {
+				return func(w http.ResponseWriter, r *http.Request) {
+					w.WriteHeader(500)
+				}
+			},
+		},
+		{
+			name:        "returns connection errors",
+			expectError: true,
+			handler: func(t *testing.T) http.HandlerFunc {
+				return func(w http.ResponseWriter, r *http.Request) {
+					panic("whoops")
+				}
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			done := testServer(test.handler(t))
+			defer done()
+
+			gitignores, err := List()
+			if test.expectError {
+				require.Error(t, err)
+
+				if test.expectedErr != nil {
+					assert.Equal(t, test.expectedErr, err)
+				}
+			} else {
+				require.NoError(t, err)
+
+				assert.Equal(t, test.expected, gitignores)
+			}
+		})
+	}
+}
+
+func TestGet(t *testing.T) {
+	var tests = []struct {
+		name        string
+		query       string
+		handler     func(t *testing.T) http.HandlerFunc
+		expected    string
+		expectError bool
+		expectedErr error
+	}{
+		{
+			name:     "returns a gitignore, with space trimmed",
+			query:    "go,python",
+			expected: "coverage.txt\nvendor/\n__pycache__",
+			handler: func(t *testing.T) http.HandlerFunc {
+				return func(w http.ResponseWriter, r *http.Request) {
+					if r.RequestURI != "/go,python" {
+						t.Fatalf("unexpected request URI: %s", r.RequestURI)
+					}
+
+					_, err := w.Write([]byte("\ncoverage.txt\nvendor/\n__pycache__\n"))
+					if err != nil {
+						t.Fatal(err)
+					}
+
+					w.WriteHeader(200)
+				}
+			},
+		},
+		{
+			name:        "returns error on non-200 status codes",
+			expectError: true,
+			expectedErr: errors.New("gitignore.io returned status code 500 while fetching gitignore template"),
+			handler: func(t *testing.T) http.HandlerFunc {
+				return func(w http.ResponseWriter, r *http.Request) {
+					w.WriteHeader(500)
+				}
+			},
+		},
+		{
+			name:        "returns well-known 404 error",
+			expectError: true,
+			expectedErr: ErrNotFound,
+			handler: func(t *testing.T) http.HandlerFunc {
+				return func(w http.ResponseWriter, r *http.Request) {
+					w.WriteHeader(404)
+				}
+			},
+		},
+		{
+			name:        "returns connection errors",
+			expectError: true,
+			handler: func(t *testing.T) http.HandlerFunc {
+				return func(w http.ResponseWriter, r *http.Request) {
+					panic("whoops")
+				}
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			done := testServer(test.handler(t))
+			defer done()
+
+			gitignores, err := Get(test.query)
+			if test.expectError {
+				require.Error(t, err)
+
+				if test.expectedErr != nil {
+					assert.Equal(t, test.expectedErr, err)
+				}
+			} else {
+				require.NoError(t, err)
+
+				assert.Equal(t, test.expected, gitignores)
+			}
+		})
+	}
+}
+
+func testServer(handler http.HandlerFunc) func() {
+	server := httptest.NewServer(handler)
+	originalAPIBaseURL := apiBaseURL
+	apiBaseURL = server.URL
+
+	return func() {
+		apiBaseURL = originalAPIBaseURL
+		server.Close()
+	}
+}

--- a/pkg/license/license.go
+++ b/pkg/license/license.go
@@ -11,9 +11,9 @@ import (
 )
 
 var (
-	// ErrLicenseNotFound is returned by the Adapter if a license cannot be
+	// ErrNotFound is returned by the Adapter if a license cannot be
 	// found via the GitHub Licenses API.
-	ErrLicenseNotFound = errors.New("license not found")
+	ErrNotFound = errors.New("license not found")
 
 	// DefaultAdapter is the default adapter for the GitHub Licenses API.
 	DefaultAdapter = NewAdapter(github.NewClient(nil).Licenses)
@@ -67,7 +67,7 @@ func NewAdapter(service GitHubLicensesService) *Adapter {
 }
 
 // Get fetches the info for the license with name. Will return
-// ErrLicenseNotFound if the license is not recognized.
+// ErrNotFound if the license is not recognized.
 func (f *Adapter) Get(name string) (*Info, error) {
 	log.WithField("license", name).Debugf("fetching license info from GitHub")
 
@@ -75,7 +75,7 @@ func (f *Adapter) Get(name string) (*Info, error) {
 	if err != nil {
 		errResp, ok := err.(*github.ErrorResponse)
 		if ok && errResp.Response.StatusCode == 404 {
-			return nil, ErrLicenseNotFound
+			return nil, ErrNotFound
 		}
 
 		return nil, err
@@ -104,7 +104,7 @@ func (f *Adapter) List() ([]*Info, error) {
 }
 
 // Get fetches the info for the license with name using the DefaultAdapter.
-// Will return ErrLicenseNotFound if the license is not recognized.
+// Will return ErrNotFound if the license is not recognized.
 func Get(name string) (*Info, error) {
 	return DefaultAdapter.Get(name)
 }

--- a/pkg/license/license_test.go
+++ b/pkg/license/license_test.go
@@ -71,7 +71,7 @@ func TestAdapter_Get_NotFound(t *testing.T) {
 
 	_, err := adapter.Get("foo")
 	require.Error(t, err)
-	assert.Equal(t, ErrLicenseNotFound, err)
+	assert.Equal(t, ErrNotFound, err)
 }
 
 func TestAdapter_List(t *testing.T) {

--- a/pkg/project/creator_test.go
+++ b/pkg/project/creator_test.go
@@ -16,11 +16,8 @@ import (
 )
 
 func TestCreate(t *testing.T) {
-	tmpdir, err := ioutil.TempDir("", "kickoff-")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(tmpdir)
+	tmpdir, remove := newTempDir(t)
+	defer remove()
 
 	path, err := filepath.Abs("testdata/skeletons/test-skeleton")
 	if err != nil {
@@ -48,11 +45,8 @@ func TestCreate(t *testing.T) {
 }
 
 func TestCreate_DryRun(t *testing.T) {
-	tmpdir, err := ioutil.TempDir("", "kickoff-")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(tmpdir)
+	tmpdir, remove := newTempDir(t)
+	defer remove()
 
 	path, err := filepath.Abs("testdata/skeletons/test-skeleton")
 	if err != nil {
@@ -75,11 +69,8 @@ func TestCreate_DryRun(t *testing.T) {
 }
 
 func TestCreate_IllegalTemplateFilename(t *testing.T) {
-	tmpdir, err := ioutil.TempDir("", "kickoff-")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(tmpdir)
+	tmpdir, remove := newTempDir(t)
+	defer remove()
 
 	path, err := filepath.Abs("testdata/skeletons/test-skeleton")
 	if err != nil {
@@ -107,11 +98,8 @@ func TestCreate_IllegalTemplateFilename(t *testing.T) {
 }
 
 func TestCreate_EmptyTemplateFilename(t *testing.T) {
-	tmpdir, err := ioutil.TempDir("", "kickoff-")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(tmpdir)
+	tmpdir, remove := newTempDir(t)
+	defer remove()
 
 	path, err := filepath.Abs("testdata/skeletons/test-skeleton")
 	if err != nil {
@@ -136,4 +124,13 @@ func TestCreate_EmptyTemplateFilename(t *testing.T) {
 	expectedErr := errors.New(`templated filename "{{.Values.filename}}" resolved to an empty string`)
 
 	assert.Equal(t, expectedErr, err)
+}
+
+func newTempDir(t *testing.T) (string, func()) {
+	tmpdir, err := ioutil.TempDir("", "kickoff-")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	return tmpdir, func() { os.RemoveAll(tmpdir) }
 }


### PR DESCRIPTION
This addresses #23 with the only difference that instead of the GitHub
API, gitignore.io is used to fetch .gitignore templates as it provides a
greater variety of those and also supports composing multiple templates
into one .gitignore already so that we do not need to implement that
ourselves.