### PR TITLE
fetch all remote refs and branches

### DIFF
--- a/pkg/skeleton/config.go
+++ b/pkg/skeleton/config.go
@@ -21,7 +21,7 @@ type Config struct {
 
 // Reference is a reference to a skeleton in a specific repository.
 type Reference struct {
-	RepositoryURL string `json:"repositoryURL"`
+	RepositoryURL string `json:"repositoryURL,omitempty"`
 	SkeletonName  string `json:"skeletonName"`
 }
 

--- a/pkg/skeleton/repo.go
+++ b/pkg/skeleton/repo.go
@@ -11,6 +11,7 @@ import (
 	"github.com/apex/log"
 	"github.com/martinohmann/kickoff/pkg/file"
 	git "gopkg.in/src-d/go-git.v4"
+	"gopkg.in/src-d/go-git.v4/config"
 	"gopkg.in/src-d/go-git.v4/plumbing"
 )
 
@@ -175,7 +176,9 @@ func openOrCloneGitRepository(info *RepositoryInfo) (*git.Repository, error) {
 	case err != nil:
 		return nil, err
 	default:
-		err := repo.Fetch(&git.FetchOptions{})
+		err := repo.Fetch(&git.FetchOptions{
+			RefSpecs: []config.RefSpec{"refs/*:refs/*", "HEAD:refs/heads/HEAD"},
+		})
 		if err != nil && err != git.NoErrAlreadyUpToDate {
 			return nil, err
 		}


### PR DESCRIPTION
This fixes a bug where changes in a remote branch were not reflected in
the locally cached copy.