### PR TITLE
print usage on invalid CLI arguments

### DIFF
--- a/pkg/cmd/completion.go
+++ b/pkg/cmd/completion.go
@@ -10,7 +10,7 @@ import (
 
 func NewCompletionCmd(streams cli.IOStreams) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "completion",
+		Use:   "completion <shell>",
 		Short: "Shell completion",
 		Long: cmdutil.LongDesc(`
 			Configure your shell to load kickoff completions.

--- a/pkg/cmd/init.go
+++ b/pkg/cmd/init.go
@@ -27,6 +27,7 @@ func NewInitCmd(streams cli.IOStreams) *cobra.Command {
 		Long: cmdutil.LongDesc(`
 			Interactively initialize the kickoff configuration.
 		`),
+		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			err := o.Complete()
 			if err != nil {

--- a/pkg/cmd/project/create.go
+++ b/pkg/cmd/project/create.go
@@ -21,7 +21,7 @@ func NewCreateCmd() *cobra.Command {
 	o := &CreateOptions{}
 
 	cmd := &cobra.Command{
-		Use:   "create <skeleton-name> [<skeleton-name>...] <output-dir>",
+		Use:   "create <skeleton-name> <output-dir>",
 		Short: "Create a project from a skeleton",
 		Long: cmdutil.LongDesc(`
 			Create a project from a skeleton.`),

--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -11,12 +11,24 @@ func NewRootCmd(streams cli.IOStreams) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:           "kickoff",
-		SilenceUsage:  true,
 		SilenceErrors: true,
-		PersistentPreRun: func(_ *cobra.Command, _ []string) {
+		PersistentPreRun: func(cmd *cobra.Command, _ []string) {
 			if verbose {
 				log.SetLevel(log.DebugLevel)
 			}
+
+			// We silence usage output here instead of doing so while
+			// initializing the struct above because we want to print the usage
+			// if the user actually misused the CLI (e.g. missing arguments,
+			// wrong flags), but we do not want to show the usage on errors
+			// that occurred when the CLI arguments where actually valid (e.g.
+			// user queried for a skeleton that does not exist). Since
+			// PersistentPreRun is called after argument parsing happened, we
+			// silence the usage here for all subsequent errors.
+			//
+			// Also see the following issue:
+			// https://github.com/spf13/cobra/issues/340#issuecomment-378726225
+			cmd.SilenceUsage = true
 		},
 	}
 

--- a/pkg/cmd/version.go
+++ b/pkg/cmd/version.go
@@ -24,6 +24,7 @@ func NewVersionCmd(streams cli.IOStreams) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "version",
 		Short: "Displays the version",
+		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			err := o.Validate()
 			if err != nil {


### PR DESCRIPTION
This improves the usability by printing the command usage if the user
provides the wrong number of arguments or invalid flags to a subcommand.

Previously, only a short message like

    accepts 1 arg(s), received 0

or

    unknown flag: --foobar

was shown.

Now the full usage with example will be printed above the error in case
argument parsing fails.

Please note that command usage is not printed if the user provided valid
arguments but the command fails due to other reasons (e.g. usage queries
for a skeleton that does not exist).