### PR TITLE
handle `~` in local repo paths

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/imdario/mergo v0.3.8
 	github.com/kirsle/configdir v0.0.0-20170128060238-e45d2f54772f
 	github.com/mattn/go-colorable v0.1.2
+	github.com/mitchellh/go-homedir v1.1.0
 	github.com/olekukonko/tablewriter v0.0.4
 	github.com/spf13/afero v1.1.2
 	github.com/spf13/cobra v0.0.5

--- a/pkg/cmd/skeleton/list.go
+++ b/pkg/cmd/skeleton/list.go
@@ -3,6 +3,7 @@ package skeleton
 import (
 	"github.com/martinohmann/kickoff/pkg/cli"
 	"github.com/martinohmann/kickoff/pkg/cmdutil"
+	"github.com/martinohmann/kickoff/pkg/homedir"
 	"github.com/martinohmann/kickoff/pkg/skeleton"
 	"github.com/spf13/cobra"
 )
@@ -54,7 +55,12 @@ func (o *ListOptions) Run() error {
 	tw.SetHeader("RepoName", "Name", "Path")
 
 	for _, skeleton := range skeletons {
-		tw.Append(skeleton.Repo.Name, skeleton.Name, skeleton.Path)
+		path, err := homedir.Collapse(skeleton.Path)
+		if err != nil {
+			return err
+		}
+
+		tw.Append(skeleton.Repo.Name, skeleton.Name, path)
 	}
 
 	tw.Render()

--- a/pkg/homedir/homedir.go
+++ b/pkg/homedir/homedir.go
@@ -1,0 +1,44 @@
+// Package homedir provides functionality to expand `~` to the absolute home
+// directory of a user and vice-versa.
+package homedir
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+
+	homedir "github.com/mitchellh/go-homedir"
+)
+
+// Collapse replaces the homedir in absolute paths with `~`. E.g.
+// `/home/user/foo` will be rewritten to `~/foo`. Relative paths are returned
+// as is. Returns an error of the home dir of the current user cannot be
+// determined.
+func Collapse(path string) (string, error) {
+	if !filepath.IsAbs(path) {
+		return path, nil
+	}
+
+	home, err := homedir.Dir()
+	if err != nil {
+		return "", err
+	}
+
+	unprefixed := strings.TrimPrefix(path, home)
+	if unprefixed == path {
+		return path, nil
+	}
+
+	if len(unprefixed) == 0 {
+		return "~", nil
+	}
+
+	return fmt.Sprintf("~/%s", strings.TrimLeft(unprefixed, "/")), nil
+}
+
+// Expand expands the path to include the home directory if the path
+// is prefixed with `~`. If it isn't prefixed with `~`, the path is
+// returned as-is.
+func Expand(path string) (string, error) {
+	return homedir.Expand(path)
+}

--- a/pkg/homedir/homedir_test.go
+++ b/pkg/homedir/homedir_test.go
@@ -1,0 +1,82 @@
+package homedir
+
+import (
+	"os"
+	"testing"
+
+	gohomedir "github.com/mitchellh/go-homedir"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCollapse(t *testing.T) {
+	tests := []struct {
+		name        string
+		home        string
+		path        string
+		expected    string
+		expectedErr error
+	}{
+		{
+			name:     "full path gets collapsed",
+			home:     "/home/user",
+			path:     "/home/user/foo",
+			expected: "~/foo",
+		},
+		{
+			name:     "full path with trailing slash gets collapsed",
+			home:     "/home/user/",
+			path:     "/home/user/foo",
+			expected: "~/foo",
+		},
+		{
+			name:     "home gets collapsed",
+			home:     "/home/user",
+			path:     "/home/user",
+			expected: "~",
+		},
+		{
+			name:     "relative paths are left untouched",
+			home:     "/home/user",
+			path:     "./foo/bar",
+			expected: "./foo/bar",
+		},
+		{
+			name:     "absolute paths outside of home are left untouched",
+			home:     "/home/user",
+			path:     "/usr/local/bin/kickoff",
+			expected: "/usr/local/bin/kickoff",
+		},
+	}
+
+	originalDisableCache := gohomedir.DisableCache
+	gohomedir.DisableCache = true
+	defer func() {
+		gohomedir.DisableCache = originalDisableCache
+	}()
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			restore := overrideHome(test.home)
+			defer restore()
+
+			collapsed, err := Collapse(test.path)
+			if test.expectedErr != nil {
+				require.Error(t, err)
+				assert.Equal(t, test.expectedErr, err)
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, test.expected, collapsed)
+			}
+		})
+	}
+}
+
+func overrideHome(path string) func() {
+	originalHome := os.Getenv("HOME")
+	os.Setenv("HOME", path)
+
+	return func() {
+		os.Setenv("HOME", originalHome)
+	}
+}

--- a/pkg/skeleton/info.go
+++ b/pkg/skeleton/info.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/kirsle/configdir"
+	"github.com/martinohmann/kickoff/pkg/homedir"
 )
 
 // Info holds information about a skeleton.
@@ -126,7 +127,12 @@ func ParseRepositoryURL(rawurl string) (*RepositoryInfo, error) {
 	info := &RepositoryInfo{}
 
 	if u.Host == "" {
-		abspath, err := filepath.Abs(u.Path)
+		path, err := homedir.Expand(u.Path)
+		if err != nil {
+			return nil, err
+		}
+
+		abspath, err := filepath.Abs(path)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
This adds code to resolve `~` in local paths to the user's home
directory. It also ensures that the user's home dir is replaced with `~`
in the output of `repository list` and `skeleton list` to make paths
shorter.