### PR TITLE
add --overwrite flag to project create command

### DIFF
--- a/pkg/cmd/project/create.go
+++ b/pkg/cmd/project/create.go
@@ -47,8 +47,11 @@ func NewCreateCmd() *cobra.Command {
 			# Composition of multiple skeletons (comma separated)
 			kickoff project create firstskeleton,secondskeleton,thirdskeleton ~/repos/myproject
 
-			# Forces overwrite of skeleton files in existing project
-			kickoff project create myskeleton ~/repos/myproject --force`),
+			# Forces creation of project in existing directory, retaining existing files
+			kickoff project create myskeleton ~/repos/myproject --force
+
+			# Forces creation of project in existing directory, overwriting existing files
+			kickoff project create myskeleton ~/repos/myproject --force --overwrite`),
 		Args: cobra.ExactArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if err := o.Complete(args); err != nil {
@@ -69,6 +72,7 @@ func NewCreateCmd() *cobra.Command {
 	o.ConfigFlags.AddFlags(cmd)
 
 	cmdutil.AddForceFlag(cmd, &o.Force)
+	cmdutil.AddOverwriteFlag(cmd, &o.Overwrite)
 
 	return cmd
 }
@@ -80,6 +84,7 @@ type CreateOptions struct {
 	Skeletons []string
 	DryRun    bool
 	Force     bool
+	Overwrite bool
 
 	rawValues []string
 	initGit   bool
@@ -175,10 +180,11 @@ func (o *CreateOptions) Run() error {
 	}
 
 	options := &project.CreateOptions{
-		DryRun:  o.DryRun,
-		Config:  o.Project,
-		Values:  o.Values,
-		InitGit: o.initGit,
+		DryRun:    o.DryRun,
+		Config:    o.Project,
+		Values:    o.Values,
+		InitGit:   o.initGit,
+		Overwrite: o.Overwrite,
 	}
 
 	if o.Project.HasLicense() {

--- a/pkg/cmdutil/flags.go
+++ b/pkg/cmdutil/flags.go
@@ -18,7 +18,12 @@ func AddConfigFlag(cmd *cobra.Command, val *string) {
 
 // AddForceFlag adds the --force flag to cmd and binds it to val.
 func AddForceFlag(cmd *cobra.Command, val *bool) {
-	cmd.Flags().BoolVar(val, "force", *val, "Forces overwrite of existing output directory")
+	cmd.Flags().BoolVar(val, "force", *val, "Forces writing into existing output directory")
+}
+
+// AddOverwriteFlag adds the --overwrite flag to cmd and binds it to val.
+func AddOverwriteFlag(cmd *cobra.Command, val *bool) {
+	cmd.Flags().BoolVar(val, "overwrite", *val, "Overwrite files that are already present in output directory")
 }
 
 // ConfigFlags provide a flag for configuring the path to the kickoff config


### PR DESCRIPTION
This causes a change to the default behaviour. Previously, files already
existing in the target dir were overwritten. It is safer to retain
those files by default and only overwrite them if the user explicitly
passes the `--overwrite` flag to the `project create` command.

See the updated usage examples in `pkg/cmd/project/create.go`.

The log output of the create command looks something like this if files are already present:
```
• creating project in /tmp/foobarbaz
• target exists, skipping           path=.
• target exists, skipping           path.src=README.md.skel  path.target=README.md
• target exists, skipping           path=LICENSE
• project creation complete
```