### PR TITLE
add support for conditionally creating files

### DIFF
--- a/docs/skeletons/templating.md
+++ b/docs/skeletons/templating.md
@@ -33,7 +33,7 @@ template rendering engine.
 Below is a simply example of a skeleton template file called `README.md.skel`:
 
 {% raw %}
-```markdown
+```mustache
 # {{.Project.Name}}
 
 [![Build Status](https://travis-ci.org/{{.Project.Owner}}/{{.Project.Name}}.svg?branch=master)](https://travis-ci.org/{{.Project.Owner}}/{{.Project.Name}})
@@ -103,15 +103,14 @@ values:
   myVar: myValue
 
 # on project creation via --set:
-kickoff project create default ~/myproj --set myVar=myValue
+$ kickoff project create default ~/myproj --set myVar=myValue
 
 # on project creation via --values:
-kickoff project create default ~/myproj --values value.yaml
+$ kickoff project create default ~/myproj --values values.yaml
 
-# contents of values.yaml:
+# where values.yaml contains myVar:
 ---
 myVar: myValue
-
 ```
 
 ## Project template variables
@@ -162,6 +161,44 @@ the project is named `myproject`.
 It is also possible to put arbitrary files
 into these directories. These will be moved to the correct place after the
 directory name was resolved. You can take a look at [this example skeleton](https://github.com/martinohmann/kickoff-skeletons/tree/master/skeletons/golang/cli) in the [kickoff-skeletons](https://github.com/martinohmann/kickoff-skeletons) repository which makes use of this feature.
+
+## Conditional inclusion of files
+
+Sometimes it might be useful to only include files in a project based on the
+value of some variable. Kickoff will skip the creation of a file in the project
+directory when the following rules apply:
+
+- The file is a `.skel` template.
+- The file content has a length of zero bytes after template rendering.
+
+To make a template conditionally render to zero bytes, you can create a `.skel`
+template with a content like this:
+
+{% raw %}
+```mustache
+{{- if .Values.includeFile }}
+This will be rendered conditionally
+{{ end -}}
+```
+
+**Note:** make sure you use `{{-` and `-}}` to trim whitespace surrounding your
+conditional to ensure that the rendered result is zero bytes long when the
+conditional evaluates to `false`.
+{% endraw %}
+
+In the `.kickoff.yaml` of the skeleton, set the `includeFile` value to `false`:
+
+```yaml
+values:
+  includeFile: false
+```
+
+Now, the file will only be written to the project if `includeFile` is set to
+`true` via the `--set` or `--values` as described in the [Accessing and setting
+template variables section](#accessing-and-setting-template-variables).
+
+**Note:** You can also force the inclusion of any empty file using the
+`--allow-empty` flag upon project creation.
 
 ## Next steps
 

--- a/pkg/cmd/project/create.go
+++ b/pkg/cmd/project/create.go
@@ -88,11 +88,12 @@ type CreateOptions struct {
 	cmdutil.ConfigFlags
 	cmdutil.TimeoutFlag
 
-	OutputDir string
-	Skeletons []string
-	DryRun    bool
-	Force     bool
-	Overwrite bool
+	OutputDir  string
+	Skeletons  []string
+	DryRun     bool
+	Force      bool
+	Overwrite  bool
+	AllowEmpty bool
 
 	rawValues   []string
 	valuesFiles []string
@@ -112,7 +113,9 @@ func (o *CreateOptions) AddFlags(cmd *cobra.Command) {
 	cmd.Flags().StringArrayVar(&o.valuesFiles, "values", o.valuesFiles, "Load custom values from provided file, making them available to .skel templates. Values passed via --set take precedence")
 	cmd.Flags().StringArrayVar(&o.rawValues, "set", o.rawValues, "Set custom values of the form key1=value1,key2=value2,deeply.nested.key3=value that are then made available to .skel templates")
 
-	cmd.Flags().BoolVar(&o.initGit, "init-git", o.initGit, "Initialize git in the project directory.")
+	cmd.Flags().BoolVar(&o.initGit, "init-git", o.initGit, "Initialize git in the project directory")
+
+	cmd.Flags().BoolVar(&o.AllowEmpty, "allow-empty", o.AllowEmpty, "If true, empty files that are the result of template rendering will still be created in the output directory")
 }
 
 func (o *CreateOptions) Complete(args []string) (err error) {
@@ -204,11 +207,12 @@ func (o *CreateOptions) Run() error {
 	}
 
 	options := &project.CreateOptions{
-		DryRun:    o.DryRun,
-		Config:    o.Project,
-		Values:    o.Values,
-		InitGit:   o.initGit,
-		Overwrite: o.Overwrite,
+		DryRun:     o.DryRun,
+		Config:     o.Project,
+		Values:     o.Values,
+		InitGit:    o.initGit,
+		Overwrite:  o.Overwrite,
+		AllowEmpty: o.AllowEmpty,
 	}
 
 	if o.Project.HasLicense() {

--- a/pkg/project/creator.go
+++ b/pkg/project/creator.go
@@ -21,13 +21,14 @@ import (
 // DryRun is set to true, actions will only be logged, but nothing will be
 // written to the project output dir.
 type CreateOptions struct {
-	DryRun    bool
-	Config    config.Project
-	Values    template.Values
-	Gitignore string
-	InitGit   bool
-	Overwrite bool
-	License   *license.Info
+	DryRun     bool
+	Config     config.Project
+	Values     template.Values
+	Gitignore  string
+	InitGit    bool
+	Overwrite  bool
+	AllowEmpty bool
+	License    *license.Info
 }
 
 // CreateProject creates a new project with given options from skeleton s in
@@ -63,7 +64,7 @@ func (c *Creator) CreateProject(s *skeleton.Skeleton, targetDir string) error {
 		return err
 	}
 
-	fw := NewSkeletonFileWriter(c.Filesystem, c.Options.Overwrite)
+	fw := NewSkeletonFileWriter(c.Filesystem, c.Options.Overwrite, c.Options.AllowEmpty)
 
 	log.Infof("creating project in %s", targetDir)
 

--- a/pkg/project/creator_test.go
+++ b/pkg/project/creator_test.go
@@ -144,6 +144,25 @@ func TestCreate(t *testing.T) {
 				assert.NotEqual(t, `do not touch`, string(contents))
 			},
 		},
+		{
+			name:          "does not create file if template rendered to an empty string",
+			createOptions: &CreateOptions{},
+			validate: func(t *testing.T, outputDir string) {
+				_, err := ioutil.ReadFile(filepath.Join(outputDir, "optional-file"))
+				require.True(t, os.IsNotExist(err))
+			},
+		},
+		{
+			name: "does create file if template rendered to an empty string and AllowEmpty is true",
+			createOptions: &CreateOptions{
+				AllowEmpty: true,
+			},
+			validate: func(t *testing.T, outputDir string) {
+				contents, err := ioutil.ReadFile(filepath.Join(outputDir, "optional-file"))
+				require.NoError(t, err)
+				assert.Len(t, contents, 0)
+			},
+		},
 	}
 
 	for _, test := range tests {

--- a/pkg/testdata/repos/repo1/skeletons/advanced/.kickoff.yaml
+++ b/pkg/testdata/repos/repo1/skeletons/advanced/.kickoff.yaml
@@ -15,5 +15,6 @@
 values:
   somekey: somevalue
   filename: foobar
+  optionalContent: ''
   travis:
     enabled: false

--- a/pkg/testdata/repos/repo1/skeletons/advanced/optional-file.skel
+++ b/pkg/testdata/repos/repo1/skeletons/advanced/optional-file.skel
@@ -1,0 +1,3 @@
+{{- with .Values.optionalContent }}
+{{ . }}
+{{ end -}}


### PR DESCRIPTION
This implements the proposal in #13.

Additionally it adds the `--allow-empty` flag to the `project create` command to create files for templates that render to an empty string in the output directory nevertheless.