### PR TITLE
remove email from config

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -54,7 +54,6 @@ The kickoff configuration file structure looks like this:
 ```yaml
 ---
 project:
-  email: johndoe@example.com
   gitignore: none
   host: github.com
   license: none
@@ -66,10 +65,13 @@ values: {}
 
 ## Project specific configuration
 
-The `email`, `owner` and `host` configuration fields are useful to be able to
-create project specific links or copyright notices in skeleton templates.
+The `owner` and `host` configuration fields are useful to be able to create
+project specific links in skeleton templates. The `owner` will also be injected
+into the `[fullname]` field of a `LICENSE` file, if you are choosing to
+automatically include one upon project creation, see the next section for
+configuring a default project license.
 
-### Configuring a default `license`
+### Configuring a default project `license`
 
 If you want to set a default license that is used for every new project (unless
 overridden), you can set that in the `license` field of the `project`
@@ -88,7 +90,7 @@ Showing the license text of a specific license works like this:
 $ kickoff license show mit
 ```
 
-### Configuring default `gitignore` templates
+### Configuring default project `gitignore` templates
 
 The `gitignore` field of the `project` configuration lets you specify a
 comma-separated list of `.gitignore` templates that should be added into the

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -46,7 +46,6 @@ $ kickoff init
 
 ? Project host github.com
 ? Project owner johndoe
-? Project email johndoe@example.com
 ? Do you want to set a default project license? No
 ? Do you want to select default .gitignore templates? No
 ```

--- a/docs/skeletons/templating.md
+++ b/docs/skeletons/templating.md
@@ -118,17 +118,15 @@ myVar: myValue
 Next to the user-defined `.Values`, kickoff makes a couple of variables
 available to template files upon project creation:
 
-| Variable                 | Description                                                                                                                                                                                                        |
-| ---                      | ---                                                                                                                                                                                                                |
-| `.Project.Host`          | The git host you specified during `kickoff init`, e.g. `github.com`                                                                                                                                                |
-| `.Project.Owner`         | The project owner you specified, e.g. `martinohmann`                                                                                                                                                               |
-| `.Project.Email`         | The project email you specified, e.g. `foo@bar.baz`                                                                                                                                                                |
-| `.Project.Name`          | The name you specified when running `kickoff project create`                                                                                                                                                       |
-| `.Project.License`       | The name of the license, if you picked one                                                                                                                                                                         |
-| `.Project.Gitignore`     | Comma-separated list of gitignore templates, if provided                                                                                                                                                           |
-| `.Project.URL`           | The URL to the project repo, e.g. `https://github.com/martinohmann/myproject`                                                                                                                                      |
-| `.Project.GoPackagePath` | The package path for go projects, e.g. `github.com/martinohmann/myproject`                                                                                                                                         |
-| `.Project.Author`        | If an email is present, this will resolve to `project-owner <foo@bar.baz>`, otherwise just `owner`                                                                                                                 |
+| Variable                 | Description                                                                   |
+| ---                      | ---                                                                           |
+| `.Project.Host`          | The git host you specified during `kickoff init`, e.g. `github.com`           |
+| `.Project.Owner`         | The project owner you specified, e.g. `martinohmann`                          |
+| `.Project.Name`          | The name you specified when running `kickoff project create`                  |
+| `.Project.License`       | The name of the license, if you picked one                                    |
+| `.Project.Gitignore`     | Comma-separated list of gitignore templates, if provided                      |
+| `.Project.URL`           | The URL to the project repo, e.g. `https://github.com/martinohmann/myproject` |
+| `.Project.GoPackagePath` | The package path for go projects, e.g. `github.com/martinohmann/myproject`    |
 
 ## Template functions
 

--- a/pkg/cmd/config/edit.go
+++ b/pkg/cmd/config/edit.go
@@ -114,19 +114,16 @@ func (o *EditOptions) Run() (err error) {
 
 	// Sanity check: if we fail to load the config from the tmpfile, we
 	// consider it invalid and abort without copying it back.
-	_, err = config.Load(tmpfilePath)
+	cfg, err := config.Load(tmpfilePath)
 	if err != nil {
 		return fmt.Errorf("not saving invalid kickoff config: %v", err)
 	}
 
-	log.WithFields(log.Fields{
-		"tmpfile":    tmpfilePath,
-		"configfile": o.ConfigPath,
-	}).Debug("copying back config file")
+	log.WithField("config", o.ConfigPath).Info("writing config")
 
-	err = file.Copy(tmpfilePath, o.ConfigPath)
+	err = config.Save(&cfg, o.ConfigPath)
 	if err != nil {
-		return fmt.Errorf("error while copying back config file: %v", err)
+		return fmt.Errorf("error while saving config file: %v", err)
 	}
 
 	return nil

--- a/pkg/cmd/init.go
+++ b/pkg/cmd/init.go
@@ -93,41 +93,29 @@ func (o *InitOptions) configureProject() error {
 		{
 			Name: "host",
 			Prompt: &survey.Input{
-				Message: "Project host",
+				Message: "Default project host",
 				Default: o.Project.Host,
 				Help: cmdutil.LongDesc(`
-					Project host
+					Default project host
 
 					To be able to build nice links that are related to the source code repo, e.g. links to
 					CI or docs, kickoff needs to know the hostname of your SCM platform. You can override
-					that on project creation.
+					this on project creation.
 				`),
 			},
 		},
 		{
 			Name: "owner",
 			Prompt: &survey.Input{
-				Message: "Project owner",
+				Message: "Default project owner",
 				Default: o.Project.Owner,
 				Help: cmdutil.LongDesc(`
-					Project owner
+					Default project owner
 
 					To be able to build nice links that are related to the source code repo, e.g. links to
 					CI or docs, kickoff needs to know the username that you use on your SCM platform. You
-					can override that on project creation. 
+					can override this on project creation. 
 					The project owner is automatically inserted into license texts if enabled.
-				`),
-			},
-		},
-		{
-			Name: "email",
-			Prompt: &survey.Input{
-				Message: "Project email",
-				Default: o.Project.Email,
-				Help: cmdutil.LongDesc(`
-					Project email
-
-					If set, the project email is automatically inserted into license texts next to the author.
 				`),
 			},
 		},

--- a/pkg/cmd/project/create.go
+++ b/pkg/cmd/project/create.go
@@ -103,7 +103,6 @@ type CreateOptions struct {
 func (o *CreateOptions) AddFlags(cmd *cobra.Command) {
 	cmd.Flags().BoolVar(&o.DryRun, "dry-run", o.DryRun, "Only print what would be done")
 
-	cmd.Flags().StringVar(&o.Project.Email, "email", o.Project.Email, "Project owner's e-mail")
 	cmd.Flags().StringVar(&o.Project.Gitignore, "gitignore", o.Project.Gitignore, "Comma-separated list of gitignore template to use for the project. If set this will automatically populate the .gitignore file")
 	cmd.Flags().StringVar(&o.Project.Host, "host", o.Project.Host, "Project repository host")
 	cmd.Flags().StringVar(&o.Project.License, "license", o.Project.License, "License to use for the project. If set this will automatically populate the LICENSE file")

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -86,20 +86,19 @@ func (c *Config) MergeFromFile(path string) error {
 	return mergo.Merge(c, config)
 }
 
-// Project contains project specific configuration like author, email address
-// and project name.
+// Project contains project specific configuration like git host, owner and
+// project name.
 type Project struct {
 	Host      string `json:"host"`
 	Owner     string `json:"owner"`
-	Email     string `json:"email"`
 	Name      string `json:"-"`
 	License   string `json:"license"`
 	Gitignore string `json:"gitignore"`
 }
 
-// ApplyDefaults applies defaults to unset fields. If the Owner and Email
-// fields are empty ApplyDefaults will attempt to fill them with the git config
-// values of github.user/user.name and user.email if they exist.
+// ApplyDefaults applies defaults to unset fields. If the Owner field is empty
+// ApplyDefaults will attempt to fill it with the git config values of
+// github.user or user.name if exists.
 func (p *Project) ApplyDefaults() {
 	if p.Host == "" {
 		p.Host = DefaultProjectHost
@@ -107,10 +106,6 @@ func (p *Project) ApplyDefaults() {
 
 	if p.Owner == "" {
 		p.Owner = detectProjectOwner()
-	}
-
-	if p.Email == "" {
-		p.Email = detectProjectEmail()
 	}
 
 	if p.License == "" {
@@ -145,16 +140,6 @@ func (p *Project) URL() string {
 // the project.
 func (p *Project) GoPackagePath() string {
 	return fmt.Sprintf("%s/%s/%s", p.Host, p.Owner, p.Name)
-}
-
-// Author returns a string that can be used in licenses. If an email address is
-// configured, this will look like `Owner <Email>`. `Owner` otherwise.
-func (p *Project) Author() string {
-	if p.Email != "" {
-		return fmt.Sprintf("%s <%s>", p.Owner, p.Email)
-	}
-
-	return p.Owner
 }
 
 // Load loads the config from path and returns it.
@@ -201,15 +186,4 @@ func detectProjectOwner() string {
 	}
 
 	return owner
-}
-
-func detectProjectEmail() string {
-	configKeys := []string{"user.email"}
-
-	email := getGitConfigKey(configKeys)
-	if email == "" {
-		log.Debugf("could not infer project email from git config, none of these keys found: ", strings.Join(configKeys, ", "))
-	}
-
-	return email
 }

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -12,7 +12,6 @@ func TestConfig_ApplyDefaults(t *testing.T) {
 	config := Config{
 		Project: Project{
 			Owner: "johndoe",
-			Email: "john@example.com",
 		},
 	}
 
@@ -22,7 +21,6 @@ func TestConfig_ApplyDefaults(t *testing.T) {
 		Project: Project{
 			Host:      DefaultProjectHost,
 			Owner:     "johndoe",
-			Email:     "john@example.com",
 			License:   NoLicense,
 			Gitignore: NoGitignore,
 		},
@@ -38,7 +36,7 @@ func TestConfig_ApplyDefaults(t *testing.T) {
 func TestConfig_MergeFromFile(t *testing.T) {
 	config := Config{
 		Project: Project{
-			Email: "johndoe@example.com",
+			Host: DefaultProjectHost,
 		},
 	}
 
@@ -47,8 +45,8 @@ func TestConfig_MergeFromFile(t *testing.T) {
 
 	expected := Config{
 		Project: Project{
+			Host:  DefaultProjectHost,
 			Owner: "johndoe",
-			Email: "johndoe@example.com",
 		},
 		Repositories: map[string]string{
 			"local":  "/some/local/path",
@@ -70,12 +68,4 @@ func TestProject_GoPackagePath(t *testing.T) {
 func TestProject_URL(t *testing.T) {
 	p := Project{Owner: "foo", Name: "bar", Host: "github.com"}
 	assert.Equal(t, "https://github.com/foo/bar", p.URL())
-}
-
-func TestProject_Author(t *testing.T) {
-	p1 := Project{Owner: "johndoe", Email: "john@example.com"}
-	assert.Equal(t, "johndoe <john@example.com>", p1.Author())
-
-	p2 := Project{Owner: "janedoe"}
-	assert.Equal(t, "janedoe", p2.Author())
 }

--- a/pkg/project/creator.go
+++ b/pkg/project/creator.go
@@ -74,7 +74,7 @@ func (c *Creator) CreateProject(s *skeleton.Skeleton, targetDir string) error {
 	}
 
 	if c.Options.License != nil {
-		body := strings.ReplaceAll(c.Options.License.Body, "[fullname]", c.Options.Config.Author())
+		body := strings.ReplaceAll(c.Options.License.Body, "[fullname]", c.Options.Config.Owner)
 		body = strings.ReplaceAll(body, "[year]", strconv.Itoa(time.Now().Year()))
 
 		err = c.writeFile(targetDir, "LICENSE", []byte(body), 0644)

--- a/pkg/project/creator_test.go
+++ b/pkg/project/creator_test.go
@@ -33,7 +33,6 @@ func TestCreate(t *testing.T) {
 				Gitignore: "somegitignorebody",
 				Config: config.Project{
 					Owner: "johndoe",
-					Email: "john@example.com",
 				},
 				License: &license.Info{
 					Body: `some license [fullname] [year]`,
@@ -59,7 +58,7 @@ func TestCreate(t *testing.T) {
 					},
 					{
 						path:     filepath.Join(outputDir, "LICENSE"),
-						contents: []byte(`some license johndoe <john@example.com> ` + strconv.Itoa(time.Now().Year())),
+						contents: []byte(`some license johndoe ` + strconv.Itoa(time.Now().Year())),
 					},
 				}
 


### PR DESCRIPTION
We should not expect users to enter an email address into a random tool
if the email address is not required for the tool to function correctly.
In kickoff it was only used in the `[fullname]` field of license texts,
which is not required. The project owner is sufficient there.

Therefore, we completely remove support for project email from the code
base. Skeleton creators can still opts for requiring `email` via a
custom user-defined `.Values` field.