### PR TITLE
add --repository flag

### DIFF
--- a/internal/cmd/skeleton/list.go
+++ b/internal/cmd/skeleton/list.go
@@ -19,8 +19,8 @@ func NewListCmd(streams cli.IOStreams) *cobra.Command {
 		Long: cmdutil.LongDesc(`
 			Lists all skeletons available in the configured repositories.`),
 		Example: cmdutil.Examples(`
-			# List skeletons from custom repositories
-			kickoff skeleton list --repositories my-repo=https://github.com/martinohmann/kickoff-skeletons`),
+			# List skeletons only from the "myrepo" repository
+			kickoff skeleton list --repository myrepo`),
 		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if err := o.Complete(); err != nil {

--- a/internal/cmd/skeleton/list_test.go
+++ b/internal/cmd/skeleton/list_test.go
@@ -1,27 +1,26 @@
 package skeleton
 
 import (
+	"os"
 	"testing"
 
 	"github.com/martinohmann/kickoff/internal/cli"
+	"github.com/martinohmann/kickoff/internal/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 func TestListCmd_Execute(t *testing.T) {
+	configFile := testutil.NewConfigFileBuilder(t).
+		WithRepository("default", "../../testdata/repos/repo1").
+		Create()
+	defer os.Remove(configFile.Name())
+
 	streams, _, out, _ := cli.NewTestIOStreams()
 	cmd := NewListCmd(streams)
-	cmd.SetArgs([]string{
-		"--config", "../../testdata/config/empty-config.yaml",
-		"--repositories", "default=../../testdata/repos/repo1",
-	})
+	cmd.SetArgs([]string{"--config", configFile.Name()})
 
-	err := cmd.Execute()
-	require.NoError(t, err)
+	require.NoError(t, cmd.Execute())
 
-	output := out.String()
-
-	expected := `minimal`
-
-	assert.Contains(t, output, expected)
+	assert.Contains(t, out.String(), `minimal`)
 }

--- a/internal/cmd/skeleton/show_test.go
+++ b/internal/cmd/skeleton/show_test.go
@@ -1,20 +1,27 @@
 package skeleton
 
 import (
+	"os"
 	"testing"
 
 	"github.com/martinohmann/kickoff/internal/cli"
+	"github.com/martinohmann/kickoff/internal/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 func TestShowCmd_Execute_NonexistantRepository(t *testing.T) {
+	configFile := testutil.NewConfigFileBuilder(t).
+		WithRepository("default", "../../testdata/repos/repo1").
+		Create()
+	defer os.Remove(configFile.Name())
+
 	streams, _, _, _ := cli.NewTestIOStreams()
 	cmd := NewShowCmd(streams)
 	cmd.SetArgs([]string{
 		"myskeleton",
-		"--config", "../../testdata/config/empty-config.yaml",
-		"--repositories", "default=nonexistent",
+		"--config", configFile.Name(),
+		"--repository", "nonexistent",
 	})
 
 	err := cmd.Execute()
@@ -35,12 +42,16 @@ func TestShowCmd_Execute_InvalidOutput(t *testing.T) {
 }
 
 func TestShowCmd_Execute(t *testing.T) {
+	configFile := testutil.NewConfigFileBuilder(t).
+		WithRepository("default", "../../testdata/repos/repo1").
+		Create()
+	defer os.Remove(configFile.Name())
+
 	streams, _, out, _ := cli.NewTestIOStreams()
 	cmd := NewShowCmd(streams)
 	cmd.SetArgs([]string{
 		"minimal",
-		"--config", "../../testdata/config/empty-config.yaml",
-		"--repositories", "default=../../testdata/repos/repo1",
+		"--config", configFile.Name(),
 	})
 
 	err := cmd.Execute()
@@ -53,12 +64,16 @@ func TestShowCmd_Execute(t *testing.T) {
 }
 
 func TestShowCmd_Execute_YAMLOutput(t *testing.T) {
+	configFile := testutil.NewConfigFileBuilder(t).
+		WithRepository("default", "../../testdata/repos/repo1").
+		Create()
+	defer os.Remove(configFile.Name())
+
 	streams, _, out, _ := cli.NewTestIOStreams()
 	cmd := NewShowCmd(streams)
 	cmd.SetArgs([]string{
 		"minimal",
-		"--config", "../../testdata/config/empty-config.yaml",
-		"--repositories", "default=../../testdata/repos/repo1",
+		"--config", configFile.Name(),
 		"--output", "yaml",
 	})
 
@@ -74,12 +89,16 @@ func TestShowCmd_Execute_YAMLOutput(t *testing.T) {
 }
 
 func TestShowCmd_Execute_JSONOutput(t *testing.T) {
+	configFile := testutil.NewConfigFileBuilder(t).
+		WithRepository("default", "../../testdata/repos/repo1").
+		Create()
+	defer os.Remove(configFile.Name())
+
 	streams, _, out, _ := cli.NewTestIOStreams()
 	cmd := NewShowCmd(streams)
 	cmd.SetArgs([]string{
 		"minimal",
-		"--config", "../../testdata/config/empty-config.yaml",
-		"--repositories", "default=../../testdata/repos/repo1",
+		"--config", configFile.Name(),
 		"--output", "json",
 	})
 

--- a/internal/testdata/config/values-config.yaml
+++ b/internal/testdata/config/values-config.yaml
@@ -1,3 +1,0 @@
----
-values:
-  foo: bar

--- a/internal/testutil/config.go
+++ b/internal/testutil/config.go
@@ -1,0 +1,58 @@
+package testutil
+
+import (
+	"io/ioutil"
+	"os"
+	"testing"
+
+	"github.com/martinohmann/kickoff/internal/config"
+	"github.com/martinohmann/kickoff/internal/template"
+	"github.com/stretchr/testify/require"
+)
+
+// ConfigFileBuilder is a utility to build kickoff config files in tests.
+type ConfigFileBuilder struct {
+	*testing.T
+	config.Config
+}
+
+// NewConfigFileBuilder creates a new *ConfigFileBuilder.
+func NewConfigFileBuilder(t *testing.T) *ConfigFileBuilder {
+	return &ConfigFileBuilder{T: t}
+}
+
+// WithProjectOwner sets the project.owner config field.
+func (b *ConfigFileBuilder) WithProjectOwner(owner string) *ConfigFileBuilder {
+	b.Project.Owner = owner
+	return b
+}
+
+// WithRepository adds a repository with name and url to the config.
+func (b *ConfigFileBuilder) WithRepository(name, url string) *ConfigFileBuilder {
+	if b.Repositories == nil {
+		b.Repositories = make(map[string]string)
+	}
+
+	b.Repositories[name] = url
+
+	return b
+}
+
+// WithValues sets the values in the config.
+func (b *ConfigFileBuilder) WithValues(values template.Values) *ConfigFileBuilder {
+	b.Values = values
+	return b
+}
+
+// Create creates the config file in the temp directory. The config files are
+// named `kickoff-config-*.yaml` and need to be cleaned by calling `os.Remove`
+// after tests are finished.
+//
+//  configFile := testutil.NewConfigFileBuilder(t).Create()
+//  defer os.Remove(configFile.Name())
+func (b *ConfigFileBuilder) Create() *os.File {
+	f, err := ioutil.TempFile("", "kickoff-config-*.yaml")
+	require.NoError(b, err)
+	require.NoError(b, config.Save(&b.Config, f.Name()))
+	return f
+}


### PR DESCRIPTION
This adds the --repository flag which can be used to filter for skeletons only from a specific repository. The flag can be specified multiple times. The makes the (badly designed) --repositories flag obsolete and it is thus removed.

To ease testing of commands that accept a config file, the `testutil` package was introduced which contains a `ConfigFileBuilder` for building temporary config files on the fly.

Usages of hardcoded config files in tests were replaced with the `ConfigFileBuilder` where possible.