### PR TITLE
resolve placeholders in license texts

### DIFF
--- a/internal/license/placeholders.go
+++ b/internal/license/placeholders.go
@@ -1,0 +1,31 @@
+package license
+
+import "strings"
+
+// placeholderMap contains a mapping from a field name to known placeholders
+// for it in open source license texts.
+var placeholderMap = map[string][]string{
+	"project": []string{"<program>"},
+	"author":  []string{"<name of author>", "[fullname]", "[name of copyright owner]"},
+	"year":    []string{"<year>", "[year]", "[yyyy]"},
+}
+
+// FieldMap is a map of placeholder field name and replacement values.
+type FieldMap map[string]string
+
+// ResolvePlaceholders takes a text and a field map and resolves all
+// placeholders to the replacement values in the map.
+func ResolvePlaceholders(text string, fieldMap FieldMap) string {
+	for fieldName, replacement := range fieldMap {
+		placeholders, ok := placeholderMap[fieldName]
+		if !ok {
+			continue
+		}
+
+		for _, placeholder := range placeholders {
+			text = strings.ReplaceAll(text, placeholder, replacement)
+		}
+	}
+
+	return text
+}

--- a/internal/license/placeholders_test.go
+++ b/internal/license/placeholders_test.go
@@ -1,0 +1,34 @@
+package license
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestResolvePlaceholders(t *testing.T) {
+	text := `This is a made up license text for <program>.
+
+Copyright [year] [fullname]
+
+Copyright [yyyy] [name of copyright owner]
+
+Copyright <year> <name of author>`
+
+	expected := `This is a made up license text for awesome-project.
+
+Copyright 2020 johndoe
+
+Copyright 2020 johndoe
+
+Copyright 2020 johndoe`
+
+	resolved := ResolvePlaceholders(text, FieldMap{
+		"project":        "awesome-project",
+		"author":         "johndoe",
+		"year":           "2020",
+		"someotherfield": "someothervalue",
+	})
+
+	assert.Equal(t, expected, resolved)
+}

--- a/internal/project/builder.go
+++ b/internal/project/builder.go
@@ -8,7 +8,6 @@ import (
 	"path/filepath"
 	"sort"
 	"strconv"
-	"strings"
 	"time"
 
 	"github.com/apex/log"
@@ -126,15 +125,18 @@ func (b *Builder) WithGitignore(content string) *Builder {
 // [fullname] placeholders are replaced with the owner value from the project
 // config and [year] placeholders are replaced with the current year. The
 // default is to not include a LICENSE file.
-func (b *Builder) WithLicense(license *license.Info) *Builder {
-	b.license = license
+func (b *Builder) WithLicense(info *license.Info) *Builder {
+	b.license = info
 
-	body := strings.ReplaceAll(license.Body, "[fullname]", b.config.Owner)
-	body = strings.ReplaceAll(body, "[year]", strconv.Itoa(time.Now().Year()))
+	text := license.ResolvePlaceholders(info.Body, license.FieldMap{
+		"project": b.config.Name,
+		"author":  b.config.Owner,
+		"year":    strconv.Itoa(time.Now().Year()),
+	})
 
 	return b.AddFile(&fileInfo{
 		relPath: "LICENSE",
-		content: []byte(body),
+		content: []byte(text),
 		mode:    0644,
 	})
 }


### PR DESCRIPTION
Different open source license texts use different placeholders for the same kind of information (e.g. author). Previously, kickoff only supported the placeholder style used by the MIT license (and possibly others).

This adds a mapping between field names and possible placeholder formats for it and provides a utility func to resolve placeholders.