### PR TITLE
improve skeleton file tree output

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/Masterminds/sprig/v3 v3.0.2
 	github.com/apex/log v1.1.1
 	github.com/disiqueira/gotree v1.0.0
+	github.com/disiqueira/gotree/v3 v3.0.2
 	github.com/fatih/color v1.7.0
 	github.com/ghodss/yaml v1.0.0
 	github.com/go-git/go-git/v5 v5.0.0

--- a/go.sum
+++ b/go.sum
@@ -32,6 +32,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/disiqueira/gotree v1.0.0 h1:en5wk87n7/Jyk6gVME3cx3xN9KmUCstJ1IjHr4Se4To=
 github.com/disiqueira/gotree v1.0.0/go.mod h1:7CwL+VWsWAU95DovkdRZAtA7YbtHwGk+tLV/kNi8niU=
+github.com/disiqueira/gotree/v3 v3.0.2 h1:ik5iuLQQoufZBNPY518dXhiO5056hyNBIK9lWhkNRq8=
+github.com/disiqueira/gotree/v3 v3.0.2/go.mod h1:ZuyjE4+mUQZlbpkI24AmruZKhg3VHEgPLDY8Qk+uUu8=
 github.com/emirpasic/gods v1.12.0 h1:QAUIPSaCu4G+POclxeqb3F+WPpdKqFGlw36+yOzGlrg=
 github.com/emirpasic/gods v1.12.0/go.mod h1:YfzfFFoVP/catgzJb4IKIqXjX78Ha8FMSDh3ymbK86o=
 github.com/fatih/color v1.7.0 h1:DkWD4oS2D8LGGgTQ6IvwJJXSL5Vp2ffcQg58nFV38Ys=

--- a/internal/cmd/skeleton/show.go
+++ b/internal/cmd/skeleton/show.go
@@ -3,12 +3,12 @@ package skeleton
 import (
 	"strings"
 
-	"github.com/disiqueira/gotree"
 	"github.com/ghodss/yaml"
 	"github.com/martinohmann/kickoff/internal/cli"
 	"github.com/martinohmann/kickoff/internal/cmdutil"
 	"github.com/martinohmann/kickoff/internal/homedir"
 	"github.com/martinohmann/kickoff/internal/repository"
+	"github.com/martinohmann/kickoff/internal/skeleton/filetree"
 	"github.com/spf13/cobra"
 )
 
@@ -103,16 +103,6 @@ func (o *ShowOptions) Run() error {
 			description = "-"
 		}
 
-		tree := gotree.New(skeleton.Info.Name)
-
-		for _, file := range skeleton.Files {
-			if file.RelPath == "." {
-				continue
-			}
-
-			tree.Add(file.RelPath)
-		}
-
 		parent := "-"
 		if skeleton.Parent != nil {
 			parent, err = homedir.Collapse(skeleton.Parent.Info.Path)
@@ -136,12 +126,14 @@ func (o *ShowOptions) Run() error {
 			return err
 		}
 
+		tree := filetree.Build(skeleton)
+
 		tw.Append("Name", skeleton.Info.Name)
 		tw.Append("Path", path)
 		tw.Append("Description", description)
-		tw.Append("Files", strings.TrimSpace(tree.Print()))
 		tw.Append("Parent", parent)
 		tw.Append("Values", values)
+		tw.Append("Files", tree.Print())
 
 		tw.Render()
 

--- a/internal/skeleton/filetree/tree.go
+++ b/internal/skeleton/filetree/tree.go
@@ -1,0 +1,110 @@
+// Package filetree provides a tree type which can be used to build and print
+// file trees of skeletons.
+package filetree
+
+import (
+	"strings"
+
+	gotree "github.com/disiqueira/gotree/v3"
+	"github.com/fatih/color"
+	"github.com/martinohmann/kickoff/internal/skeleton"
+)
+
+var (
+	bold  = color.New(color.Bold)
+	green = color.New(color.FgGreen)
+)
+
+type tree struct {
+	gotree.Tree
+}
+
+// Build builds a printable file tree for s.
+func Build(s *skeleton.Skeleton) gotree.Tree {
+	root := New(s.Info.Name)
+
+	for _, f := range s.Files {
+		parts := strings.Split(f.RelPath, "/")
+		if parts[0] == "." {
+			// @TODO(mohmann): the skeleton dir should be removed from the file
+			// list at one point. We'll ignore it for now.
+			continue
+		}
+		for tree := root; len(parts) > 0; parts = parts[1:] {
+			tree = tree.Add(parts[0])
+		}
+	}
+
+	return root
+}
+
+// New creates a new tree node with text.
+func New(text string) gotree.Tree {
+	return &tree{
+		Tree: gotree.New(text),
+	}
+}
+
+// Text implements gotree.Tree.
+//
+// Returns formatted node text. This is not necessarily the text that the node
+// was created with.
+func (t *tree) Text() string {
+	text := t.Tree.Text()
+	if len(t.Items()) > 0 {
+		return bold.Sprint(text + "/")
+	}
+
+	if strings.HasSuffix(text, ".skel") {
+		return green.Sprint(text)
+	}
+
+	return text
+}
+
+// AddTree implements gotree.Tree.
+//
+// It adds the other as a child of t.
+func (t *tree) AddTree(other gotree.Tree) {
+	if o, ok := other.(*tree); !ok {
+		other = &tree{o}
+	}
+	t.Tree.AddTree(other)
+}
+
+// Add implements gotree.Tree.
+//
+// It adds a new tree node with text if not present yet and returns it. If
+// present, it just returns the existing node.
+func (t *tree) Add(text string) gotree.Tree {
+	if item := t.find(text); item != nil {
+		return item
+	}
+
+	n := New(text)
+	t.AddTree(n)
+	return n
+}
+
+// Print implements gotree.Tree.
+//
+// Prints the tree with all leading and trailing whitespace trimmed.
+func (t *tree) Print() string {
+	return strings.TrimSpace(t.Tree.Print())
+}
+
+func (t *tree) find(text string) gotree.Tree {
+	for _, item := range t.Items() {
+		itemText := item.Text()
+		if ft, ok := item.(*tree); ok {
+			// use the raw text of the underlying node for comparison.
+			itemText = ft.Tree.Text()
+		}
+
+		if itemText == text {
+			return item
+		}
+	}
+
+	return nil
+}

--- a/internal/skeleton/filetree/tree_test.go
+++ b/internal/skeleton/filetree/tree_test.go
@@ -1,0 +1,35 @@
+package filetree
+
+import (
+	"testing"
+
+	"github.com/martinohmann/kickoff/internal/skeleton"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBuild(t *testing.T) {
+	s := &skeleton.Skeleton{
+		Info: &skeleton.Info{Name: "my/skeleton"},
+		Files: []*skeleton.File{
+			{RelPath: "."},
+			{RelPath: ".kickoff.yaml"},
+			{RelPath: "README.md.skel"},
+			{RelPath: "foo/bar"},
+			{RelPath: "foo/sometemplate.skel"},
+			{RelPath: "foo/{{.Values.filename}}/qux"},
+		},
+	}
+
+	tree := Build(s)
+
+	expected := `my/skeleton
+├── .kickoff.yaml
+├── README.md.skel
+└── foo/
+    ├── bar
+    ├── sometemplate.skel
+    └── {{.Values.filename}}/
+        └── qux`
+
+	assert.Equal(t, expected, tree.Print())
+}


### PR DESCRIPTION
This fixes the skeleton file tree output. Previously, the `kickoff
skeleton show` command printed a flat list of filenames where only the
first level resembled a tree like structure which looked like this:

```
Files           golang/cli
                └── .gitignore.skel
                └── .golangci.yml
                └── .travis.yml.skel
                └── Makefile.skel
                └── README.md.skel
                └── cmd
                └── cmd/{{.Project.Name}}
                └── cmd/{{.Project.Name}}/main.go.skel
                └── doc.go.skel
                └── go.mod.skel
                └── pkg
                └── pkg/version
                └── pkg/version/version.go
```

The new implementation will produce tree which looks like this:

```
Files           golang/cli
                ├── .gitignore.skel
                ├── .golangci.yml
                ├── .travis.yml.skel
                ├── Makefile.skel
                ├── README.md.skel
                ├── cmd/
                │   └── {{.Project.Name}}/
                │       └── main.go.skel
                ├── doc.go.skel
                ├── go.mod.skel
                └── pkg/
                    └── version/
                        └── version.go
```

It also colors directories and *.skel files to make them stand out a
little. Also the file list is now printed as the last item.