### PR TITLE
align third-party API client structure

### DIFF
--- a/internal/cmd/gitignore/list.go
+++ b/internal/cmd/gitignore/list.go
@@ -14,6 +14,8 @@ import (
 func NewListCmd(streams cli.IOStreams) *cobra.Command {
 	timeoutFlag := cmdutil.NewDefaultTimeoutFlag()
 
+	client := gitignore.NewClient(nil)
+
 	cmd := &cobra.Command{
 		Use:     "list",
 		Aliases: []string{"ls"},
@@ -27,7 +29,7 @@ func NewListCmd(streams cli.IOStreams) *cobra.Command {
 			ctx, cancel := timeoutFlag.Context()
 			defer cancel()
 
-			gitignores, err := gitignore.List(ctx)
+			gitignores, err := client.ListTemplates(ctx)
 			if err != nil {
 				return fmt.Errorf("failed to fetch gitignore templates due to: %v", err)
 			}

--- a/internal/cmd/gitignore/show.go
+++ b/internal/cmd/gitignore/show.go
@@ -14,6 +14,8 @@ import (
 func NewShowCmd(streams cli.IOStreams) *cobra.Command {
 	timeoutFlag := cmdutil.NewDefaultTimeoutFlag()
 
+	client := gitignore.NewClient(nil)
+
 	cmd := &cobra.Command{
 		Use:   "show <name>",
 		Short: "Fetch a gitignore template",
@@ -32,7 +34,7 @@ func NewShowCmd(streams cli.IOStreams) *cobra.Command {
 			ctx, cancel := timeoutFlag.Context()
 			defer cancel()
 
-			gitignore, err := gitignore.Get(ctx, args[0])
+			gitignore, err := client.GetTemplate(ctx, args[0])
 			if err != nil {
 				return fmt.Errorf("failed to fetch gitignore templates due to: %v", err)
 			}

--- a/internal/cmd/init.go
+++ b/internal/cmd/init.go
@@ -22,8 +22,10 @@ import (
 // the kickoff configuration.
 func NewInitCmd(streams cli.IOStreams) *cobra.Command {
 	o := &InitOptions{
-		IOStreams:   streams,
-		TimeoutFlag: cmdutil.NewDefaultTimeoutFlag(),
+		IOStreams:       streams,
+		TimeoutFlag:     cmdutil.NewDefaultTimeoutFlag(),
+		GitignoreClient: gitignore.NewClient(nil),
+		LicenseClient:   license.NewClient(nil),
 	}
 
 	cmd := &cobra.Command{
@@ -55,6 +57,9 @@ type InitOptions struct {
 	cli.IOStreams
 	cmdutil.ConfigFlags
 	cmdutil.TimeoutFlag
+
+	GitignoreClient *gitignore.Client
+	LicenseClient   *license.Client
 }
 
 // Complete completes the command options.
@@ -139,7 +144,7 @@ func (o *InitOptions) configureLicense() error {
 	ctx, cancel := o.TimeoutFlag.Context()
 	defer cancel()
 
-	licenses, err := license.List(ctx)
+	licenses, err := o.LicenseClient.ListLicenses(ctx)
 	if err != nil {
 		log.Debugf("skipping license configuration due to: %v", err)
 	} else if len(licenses) > 0 {
@@ -207,7 +212,7 @@ func (o *InitOptions) configureGitignoreTemplates() error {
 	ctx, cancel := o.TimeoutFlag.Context()
 	defer cancel()
 
-	gitignoreOptions, err := gitignore.List(ctx)
+	gitignoreOptions, err := o.GitignoreClient.ListTemplates(ctx)
 	if err != nil {
 		log.Debugf("skipping gitignore configuration due to: %v", err)
 	} else if len(gitignoreOptions) > 0 {

--- a/internal/cmd/license/list.go
+++ b/internal/cmd/license/list.go
@@ -14,6 +14,8 @@ import (
 func NewListCmd(streams cli.IOStreams) *cobra.Command {
 	timeoutFlag := cmdutil.NewDefaultTimeoutFlag()
 
+	client := license.NewClient(nil)
+
 	cmd := &cobra.Command{
 		Use:     "list",
 		Aliases: []string{"ls"},
@@ -25,7 +27,7 @@ func NewListCmd(streams cli.IOStreams) *cobra.Command {
 			ctx, cancel := timeoutFlag.Context()
 			defer cancel()
 
-			licenses, err := license.List(ctx)
+			licenses, err := client.ListLicenses(ctx)
 			if err != nil {
 				return fmt.Errorf("failed to fetch licenses due to: %v", err)
 			}

--- a/internal/cmd/license/show.go
+++ b/internal/cmd/license/show.go
@@ -14,6 +14,8 @@ import (
 func NewShowCmd(streams cli.IOStreams) *cobra.Command {
 	timeoutFlag := cmdutil.NewDefaultTimeoutFlag()
 
+	client := license.NewClient(nil)
+
 	cmd := &cobra.Command{
 		Use:   "show <key>",
 		Short: "Fetch a license text",
@@ -27,7 +29,7 @@ func NewShowCmd(streams cli.IOStreams) *cobra.Command {
 			ctx, cancel := timeoutFlag.Context()
 			defer cancel()
 
-			license, err := license.Get(ctx, args[0])
+			license, err := client.GetLicense(ctx, args[0])
 			if err != nil {
 				return fmt.Errorf("failed to fetch license text due to: %v", err)
 			}

--- a/internal/gitignore/gitignore.go
+++ b/internal/gitignore/gitignore.go
@@ -15,32 +15,41 @@ import (
 	"github.com/apex/log"
 )
 
-var (
-	// apiBaseURL is a variable and not a constant so it can be replaced in
-	// tests.
-	apiBaseURL = "https://gitignore.io/api"
+const defaultBaseURL = "https://www.toptal.com/developers/gitignore/api"
 
-	// ErrNotFound is returned if a gitignore template could not be found.
-	ErrNotFound = errors.New("gitignore not found")
-)
+// ErrNotFound is returned if a gitignore template could not be found.
+var ErrNotFound = errors.New("gitignore template not found")
 
-// Get fetches the gitignore template for query from gitignore.io. The query
-// can be a comma-separated list of gitignore templates (e.g. "go,python")
-// which are combined into a single gitignore template. Will return an error if
-// the http connection fails or if the response status code is not 200. Will
+// Client can fetch gitignore templates.
+type Client struct {
+	*http.Client
+	BaseURL string
+}
+
+// NewClient creates a new *Client which will use httpClient for making http
+// requests. If httpClient is nil, http.DefaultClient will be used instead.
+func NewClient(httpClient *http.Client) *Client {
+	return &Client{
+		Client:  httpClient,
+		BaseURL: defaultBaseURL,
+	}
+}
+
+// GetTemplate fetches the gitignore template for query. The query can be a
+// comma-separated list of gitignore templates (e.g. "go,python") which are
+// combined into a single gitignore template. Will return an error if the
+// http connection fails or if the response status code is not 200. Will
 // return ErrNotFound if any of the requested gitignore templates cannot be
 // found.
-func Get(ctx context.Context, query string) (string, error) {
-	log.WithField("query", query).Debug("fetching template from gitignore.io")
+func (c *Client) GetTemplate(ctx context.Context, query string) (string, error) {
+	log.WithField("query", query).Debug("fetching gitignore template")
 
-	req, err := http.NewRequest("GET", fmt.Sprintf("%s/%s", apiBaseURL, query), nil)
+	req, err := http.NewRequest("GET", c.buildRequestURL(fmt.Sprintf("/%s", query)), nil)
 	if err != nil {
 		return "", err
 	}
 
-	req = req.WithContext(ctx)
-
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := c.doRequest(ctx, req)
 	if err != nil {
 		return "", err
 	}
@@ -49,7 +58,7 @@ func Get(ctx context.Context, query string) (string, error) {
 	if resp.StatusCode == 404 {
 		return "", ErrNotFound
 	} else if resp.StatusCode != 200 {
-		return "", fmt.Errorf("gitignore.io returned status code %d while fetching gitignore template", resp.StatusCode)
+		return "", fmt.Errorf("received status code %d while fetching gitignore template", resp.StatusCode)
 	}
 
 	body, err := ioutil.ReadAll(resp.Body)
@@ -57,27 +66,25 @@ func Get(ctx context.Context, query string) (string, error) {
 	return strings.TrimSpace(string(body)), err
 }
 
-// List obtains a list of available gitignore templates from gitignore.io. Will
-// return an error if the http connection fails or the response status code is
-// not 200.
-func List(ctx context.Context) ([]string, error) {
-	log.Debug("fetching template list from gitignore.io")
+// ListTemplates obtains a list of available gitignore templates. Will
+// return an error if the http connection fails or the response status code
+// is not 200.
+func (c *Client) ListTemplates(ctx context.Context) ([]string, error) {
+	log.Debug("fetching gitignore template list")
 
-	req, err := http.NewRequest("GET", fmt.Sprintf("%s/list", apiBaseURL), nil)
+	req, err := http.NewRequest("GET", c.buildRequestURL("/list"), nil)
 	if err != nil {
 		return nil, err
 	}
 
-	req = req.WithContext(ctx)
-
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := c.doRequest(ctx, req)
 	if err != nil {
 		return nil, err
 	}
 	defer resp.Body.Close()
 
 	if resp.StatusCode != 200 {
-		return nil, fmt.Errorf("gitignore.io returned status code %d while listing gitignore templates", resp.StatusCode)
+		return nil, fmt.Errorf("received status code %d while listing gitignore templates", resp.StatusCode)
 	}
 
 	gitignores := make([]string, 0)
@@ -88,4 +95,19 @@ func List(ctx context.Context) ([]string, error) {
 	}
 
 	return gitignores, nil
+}
+
+func (c *Client) buildRequestURL(path string) string {
+	return fmt.Sprintf("%s%s", c.BaseURL, path)
+}
+
+func (c *Client) doRequest(ctx context.Context, req *http.Request) (*http.Response, error) {
+	req = req.WithContext(ctx)
+
+	httpClient := c.Client
+	if httpClient == nil {
+		httpClient = http.DefaultClient
+	}
+
+	return httpClient.Do(req)
 }

--- a/internal/license/license_test.go
+++ b/internal/license/license_test.go
@@ -37,9 +37,9 @@ func (s *mockService) List(ctx context.Context) (licenses []*github.License, res
 	return licenses, resp, args.Error(2)
 }
 
-func TestAdapter_Get(t *testing.T) {
+func TestClient_GetLicense(t *testing.T) {
 	svc := &mockService{}
-	adapter := NewAdapter(svc)
+	client := &Client{svc}
 
 	license := &github.License{
 		Key:  github.String("foo"),
@@ -49,7 +49,7 @@ func TestAdapter_Get(t *testing.T) {
 
 	svc.On("Get", mock.Anything, "foo").Return(license, &github.Response{}, nil)
 
-	info, err := adapter.Get(context.Background(), "foo")
+	info, err := client.GetLicense(context.Background(), "foo")
 	require.NoError(t, err)
 
 	expected := &Info{
@@ -61,22 +61,22 @@ func TestAdapter_Get(t *testing.T) {
 	assert.Equal(t, expected, info)
 }
 
-func TestAdapter_Get_NotFound(t *testing.T) {
+func TestClient_GetLicense_NotFound(t *testing.T) {
 	svc := &mockService{}
-	adapter := NewAdapter(svc)
+	client := &Client{svc}
 
 	svc.On("Get", mock.Anything, "foo").Return(nil, &github.Response{}, &github.ErrorResponse{
 		Response: &http.Response{StatusCode: 404},
 	})
 
-	_, err := adapter.Get(context.Background(), "foo")
+	_, err := client.GetLicense(context.Background(), "foo")
 	require.Error(t, err)
 	assert.Equal(t, ErrNotFound, err)
 }
 
-func TestAdapter_List(t *testing.T) {
+func TestClient_ListLicenses(t *testing.T) {
 	svc := &mockService{}
-	adapter := NewAdapter(svc)
+	client := &Client{svc}
 
 	licenses := []*github.License{
 		{
@@ -88,7 +88,7 @@ func TestAdapter_List(t *testing.T) {
 
 	svc.On("List", mock.Anything).Return(licenses, &github.Response{}, nil)
 
-	infos, err := adapter.List(context.Background())
+	infos, err := client.ListLicenses(context.Background())
 	require.NoError(t, err)
 
 	expected := []*Info{

--- a/internal/license/placeholders.go
+++ b/internal/license/placeholders.go
@@ -5,9 +5,9 @@ import "strings"
 // placeholderMap contains a mapping from a field name to known placeholders
 // for it in open source license texts.
 var placeholderMap = map[string][]string{
-	"project": []string{"<program>"},
-	"author":  []string{"<name of author>", "[fullname]", "[name of copyright owner]"},
-	"year":    []string{"<year>", "[year]", "[yyyy]"},
+	"project": {"<program>"},
+	"author":  {"<name of author>", "[fullname]", "[name of copyright owner]"},
+	"year":    {"<year>", "[year]", "[yyyy]"},
 }
 
 // FieldMap is a map of placeholder field name and replacement values.


### PR DESCRIPTION
This should help with the implementation of generic http response caching for offline usage.

The clients now expect an `*http.Client` which can be configured to leverage caching in the future, for now `nil` is passed which implies the usage of `http.DefaultClient`.

This is a preparation for addressing #6 and also do the same for gitignore templates.