### PR TITLE
implement --skip-file, drop --allow-empty

### DIFF
--- a/docs/skeletons/templating.md
+++ b/docs/skeletons/templating.md
@@ -161,44 +161,6 @@ It is also possible to put arbitrary files
 into these directories. These will be moved to the correct place after the
 directory name was resolved. You can take a look at [this example skeleton](https://github.com/martinohmann/kickoff-skeletons/tree/master/skeletons/golang/cli) in the [kickoff-skeletons](https://github.com/martinohmann/kickoff-skeletons) repository which makes use of this feature.
 
-## Conditional inclusion of files
-
-Sometimes it might be useful to only include files in a project based on the
-value of some variable. Kickoff will skip the creation of a file in the project
-directory when the following rules apply:
-
-- The file is a `.skel` template.
-- The file content has a length of zero bytes after template rendering.
-
-To make a template conditionally render to zero bytes, you can create a `.skel`
-template with a content like this:
-
-{% raw %}
-```mustache
-{{- if .Values.includeFile }}
-This will be rendered conditionally
-{{ end -}}
-```
-
-**Note:** make sure you use `{{-` and `-}}` to trim whitespace surrounding your
-conditional to ensure that the rendered result is zero bytes long when the
-conditional evaluates to `false`.
-{% endraw %}
-
-In the `.kickoff.yaml` of the skeleton, set the `includeFile` value to `false`:
-
-```yaml
-values:
-  includeFile: false
-```
-
-Now, the file will only be written to the project if `includeFile` is set to
-`true` via the `--set` or `--values` as described in the [Accessing and setting
-template variables section](#accessing-and-setting-template-variables).
-
-**Note:** You can also force the inclusion of any empty file using the
-`--allow-empty` flag upon project creation.
-
 ## Next steps
 
 * [Skeleton inheritance](inheritance): Inheriting from a parent skeleton.

--- a/internal/cmd/project/create.go
+++ b/internal/cmd/project/create.go
@@ -110,7 +110,7 @@ type CreateOptions struct {
 	Force          bool
 	Overwrite      bool
 	OverwriteFiles []string
-	AllowEmpty     bool
+	SkipFiles      []string
 
 	rawValues   []string
 	valuesFiles []string
@@ -132,9 +132,8 @@ func (o *CreateOptions) AddFlags(cmd *cobra.Command) {
 
 	cmd.Flags().BoolVar(&o.initGit, "init-git", o.initGit, "Initialize git in the project directory")
 
-	cmd.Flags().BoolVar(&o.AllowEmpty, "allow-empty", o.AllowEmpty, "If true, empty files that are the result of template rendering will still be created in the output directory")
-
 	cmd.Flags().StringArrayVar(&o.OverwriteFiles, "overwrite-file", o.OverwriteFiles, "Overwrite a specific file in the output directory, if present. File path must be relative to the output directory")
+	cmd.Flags().StringArrayVar(&o.SkipFiles, "skip-file", o.SkipFiles, "Skip writing a specific file to the output directory. File path must be relative to the output directory. If file is a dir, files contained in it will be skipped as well")
 }
 
 // Complete completes the project creation options.
@@ -239,9 +238,9 @@ func (o *CreateOptions) Run() error {
 	}
 
 	builder := project.NewBuilder(o.Project).
-		AllowEmpty(o.AllowEmpty).
 		OverwriteAll(o.Overwrite).
 		OverwriteFiles(o.OverwriteFiles).
+		SkipFiles(o.SkipFiles).
 		AddValues(skeleton.Values).
 		AddValues(o.Values)
 

--- a/internal/cmd/project/create.go
+++ b/internal/cmd/project/create.go
@@ -68,7 +68,10 @@ func NewCreateCmd() *cobra.Command {
 			kickoff project create myskeleton ~/repos/myproject --force --overwrite
 
 			# Forces creation of project in existing directory, selectively overwriting existing files
-			kickoff project create myskeleton ~/repos/myproject --force --overwrite-file README.md`),
+			kickoff project create myskeleton ~/repos/myproject --force --overwrite-file README.md
+
+			# Selectively skip the creating of certain files or dirs
+			kickoff project create myskeleton ~/repos/myproject --skip-file README.md`),
 		Args: cobra.ExactArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if err := o.Complete(args); err != nil {
@@ -132,7 +135,7 @@ func (o *CreateOptions) AddFlags(cmd *cobra.Command) {
 
 	cmd.Flags().BoolVar(&o.initGit, "init-git", o.initGit, "Initialize git in the project directory")
 
-	cmd.Flags().StringArrayVar(&o.OverwriteFiles, "overwrite-file", o.OverwriteFiles, "Overwrite a specific file in the output directory, if present. File path must be relative to the output directory")
+	cmd.Flags().StringArrayVar(&o.OverwriteFiles, "overwrite-file", o.OverwriteFiles, "Overwrite a specific file in the output directory, if present. File path must be relative to the output directory. If file is a dir, present files contained in it will be overwritten")
 	cmd.Flags().StringArrayVar(&o.SkipFiles, "skip-file", o.SkipFiles, "Skip writing a specific file to the output directory. File path must be relative to the output directory. If file is a dir, files contained in it will be skipped as well")
 }
 
@@ -302,8 +305,7 @@ func (o *CreateOptions) logStats(stats project.Stats) {
 	}).Info("project creation complete")
 
 	if stats.Skipped > 0 {
-		log.Warn("some targets were skipped, use --overwrite or --overwrite-file to overwrite existing " +
-			"files or --allow-empty to allow the creation of empty templates")
+		log.Warn("some targets were skipped, use --overwrite or --overwrite-file to overwrite existing files")
 	}
 
 	if o.DryRun {

--- a/internal/project/builder.go
+++ b/internal/project/builder.go
@@ -23,9 +23,9 @@ import (
 type Builder struct {
 	config config.Project
 
-	allowEmpty   bool
 	overwriteAll bool
 	overwriteMap map[string]bool
+	skipMap      map[string]bool
 	dirMap       map[string]string
 
 	fs      afero.Fs
@@ -45,6 +45,7 @@ func NewBuilder(config config.Project) *Builder {
 		config:       config,
 		dirMap:       make(map[string]string),
 		overwriteMap: make(map[string]bool),
+		skipMap:      make(map[string]bool),
 		values:       template.Values{},
 	}
 }
@@ -93,10 +94,22 @@ func (b *Builder) OverwriteFiles(paths []string) *Builder {
 	return b
 }
 
-// AllowEmpty causes templates that render to a length of zero bytes to be
-// written to the project regardless. The default is to skip empty templates.
-func (b *Builder) AllowEmpty(allowEmpty bool) *Builder {
-	b.allowEmpty = allowEmpty
+// @TODO add doc
+func (b *Builder) SkipFiles(paths []string) *Builder {
+	if b.err != nil {
+		return b
+	}
+
+	for _, path := range paths {
+		if filepath.IsAbs(path) {
+			b.err = fmt.Errorf("found absolute path in files to skip: %s", path)
+			return b
+		}
+
+		relPath := filepath.Clean(path)
+
+		b.skipMap[relPath] = true
+	}
 	return b
 }
 
@@ -191,6 +204,20 @@ func (b *Builder) shouldOverwrite(path string) bool {
 	return b.overwriteAll || b.overwriteMap[path]
 }
 
+func (b *Builder) shouldSkip(path string) bool {
+	for {
+		if b.skipMap[path] {
+			return true
+		}
+
+		if path = filepath.Dir(path); path == "." || path == "/" {
+			break
+		}
+	}
+
+	return false
+}
+
 // processFile processes f and writes the result to the targetDir.
 func (b *Builder) processFile(f File, targetDir string) error {
 	targetRelPath, err := b.buildTargetRelPath(f)
@@ -216,6 +243,12 @@ func (b *Builder) processFile(f File, targetDir string) error {
 		})
 	}
 
+	if b.shouldSkip(targetRelPath) {
+		logger.Warnf("skipping exluded %s", fileType(f))
+		b.stats.Skipped++
+		return nil
+	}
+
 	if !b.shouldOverwrite(targetRelPath) && file.Exists(targetAbsPath) {
 		logger.Warnf("skipping existing %s", fileType(f))
 		b.stats.Skipped++
@@ -233,20 +266,14 @@ func (b *Builder) writeFile(logger *log.Entry, f File, targetAbsPath string) (er
 
 		err = b.fs.MkdirAll(targetAbsPath, f.Mode())
 	case filepath.Ext(f.Path()) == ".skel":
+		logger.Info("rendering template")
+
 		var rendered string
 
 		rendered, err = b.renderTemplateFile(f)
 		if err != nil {
 			return err
 		}
-
-		if !b.allowEmpty && len(rendered) == 0 {
-			logger.Warn("skipping empty template")
-			b.stats.Skipped++
-			return nil
-		}
-
-		logger.Info("rendering template")
 
 		err = afero.WriteFile(b.fs, targetAbsPath, []byte(rendered), f.Mode())
 	default:

--- a/internal/project/builder_test.go
+++ b/internal/project/builder_test.go
@@ -138,21 +138,6 @@ func TestBuilder_Build(t *testing.T) {
 			},
 		},
 		{
-			name: "does not create file if template rendered to an empty string",
-			validate: func(t *dirTester, b *Builder) {
-				t.assertFileAbsent("optional-file")
-			},
-		},
-		{
-			name: "does create file if template rendered to an empty string and AllowEmpty is true",
-			setup: func(t *dirTester, b *Builder) {
-				b.AllowEmpty(true)
-			},
-			validate: func(t *dirTester, b *Builder) {
-				t.assertFileEmpty("optional-file")
-			},
-		},
-		{
 			name: "errors during configuration prevent build",
 			setup: func(t *dirTester, b *Builder) {
 				b.err = errors.New("whoops")


### PR DESCRIPTION
The allow-empty feature was confusing. Conditional inclusion of files can be acheived by the `--skip-file` flag now.

Also, passing a dir to the `--overwrite-file` flag will now cause existing files in the dir to be overwritten.

Closes #71 