### PR TITLE
fix(logging)!: distinguish between logs and output

### DIFF
--- a/internal/cmd/cache.go
+++ b/internal/cmd/cache.go
@@ -1,19 +1,20 @@
 package cmd
 
 import (
+	"github.com/martinohmann/kickoff/internal/cli"
 	"github.com/martinohmann/kickoff/internal/cmd/cache"
 	"github.com/spf13/cobra"
 )
 
 // NewCacheCmd creates a command which provides subcommands for interacting
 // with the kickoff cache.
-func NewCacheCmd() *cobra.Command {
+func NewCacheCmd(streams cli.IOStreams) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "cache",
 		Short: "Manage kickoff cache",
 	}
 
-	cmd.AddCommand(cache.NewCleanCmd())
+	cmd.AddCommand(cache.NewCleanCmd(streams))
 
 	return cmd
 }

--- a/internal/cmd/cache/clean.go
+++ b/internal/cmd/cache/clean.go
@@ -6,12 +6,13 @@ import (
 
 	"github.com/apex/log"
 	"github.com/kirsle/configdir"
+	"github.com/martinohmann/kickoff/internal/cli"
 	"github.com/martinohmann/kickoff/internal/cmdutil"
 	"github.com/spf13/cobra"
 )
 
 // NewCleanCmd create a command for cleaning the kickoff cache.
-func NewCleanCmd() *cobra.Command {
+func NewCleanCmd(streams cli.IOStreams) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "clean",
 		Short: "Cleans the kickoff cache",
@@ -21,14 +22,14 @@ func NewCleanCmd() *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cacheDir := configdir.LocalCache("kickoff")
 
-			log.WithField("cache.dir", cacheDir).Debug("cleaning cache")
+			log.WithField("cache.dir", cacheDir).Info("cleaning cache")
 
 			err := os.RemoveAll(cacheDir)
 			if err != nil {
 				return fmt.Errorf("failed to clean cache: %v", err)
 			}
 
-			log.Info("cache cleaned")
+			fmt.Fprintln(streams.Out, "Cache cleaned")
 
 			return nil
 		},

--- a/internal/cmd/config.go
+++ b/internal/cmd/config.go
@@ -15,7 +15,7 @@ func NewConfigCmd(streams cli.IOStreams) *cobra.Command {
 		Short:   "Manage kickoff config",
 	}
 
-	cmd.AddCommand(config.NewEditCmd())
+	cmd.AddCommand(config.NewEditCmd(streams))
 	cmd.AddCommand(config.NewShowCmd(streams))
 
 	return cmd

--- a/internal/cmd/config/edit.go
+++ b/internal/cmd/config/edit.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/apex/log"
 	"github.com/ghodss/yaml"
+	"github.com/martinohmann/kickoff/internal/cli"
 	"github.com/martinohmann/kickoff/internal/cmdutil"
 	"github.com/martinohmann/kickoff/internal/config"
 	"github.com/martinohmann/kickoff/internal/file"
@@ -25,8 +26,10 @@ var (
 
 // NewEditCmd creates a new command that opens the kickoff config in a
 // configurable editor so that the user can edit it.
-func NewEditCmd() *cobra.Command {
-	o := &EditOptions{}
+func NewEditCmd(streams cli.IOStreams) *cobra.Command {
+	o := &EditOptions{
+		IOStreams: streams,
+	}
 
 	cmd := &cobra.Command{
 		Use:   "edit",
@@ -56,6 +59,7 @@ func NewEditCmd() *cobra.Command {
 
 // EditOptions holds the options for the edit command.
 type EditOptions struct {
+	cli.IOStreams
 	cmdutil.ConfigFlags
 }
 
@@ -131,6 +135,8 @@ func (o *EditOptions) Run() (err error) {
 	if err != nil {
 		return fmt.Errorf("error while saving config file: %v", err)
 	}
+
+	fmt.Fprintln(o.Out, "Config saved")
 
 	return nil
 }

--- a/internal/cmd/config/edit_test.go
+++ b/internal/cmd/config/edit_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"testing"
 
+	"github.com/martinohmann/kickoff/internal/cli"
 	"github.com/martinohmann/kickoff/internal/template"
 	"github.com/martinohmann/kickoff/internal/testutil"
 	"github.com/stretchr/testify/assert"
@@ -12,7 +13,7 @@ import (
 )
 
 func TestGetEditCmdArgs(t *testing.T) {
-	var tests = []struct {
+	tests := []struct {
 		name     string
 		path     string
 		editor   string
@@ -88,7 +89,8 @@ func TestEditCmd_Run_InvalidEditor(t *testing.T) {
 	configBuf, err := ioutil.ReadAll(configFile)
 	require.NoError(t, err)
 
-	cmd := NewEditCmd()
+	streams, _, _, _ := cli.NewTestIOStreams()
+	cmd := NewEditCmd(streams)
 	cmd.SetArgs([]string{"--config", configFile.Name()})
 
 	expectedErrPattern := `error while launching editor command "sh -c ./nonexistent /tmp/kickoff-[0-9]+.yaml": exit status 127`

--- a/internal/cmd/init.go
+++ b/internal/cmd/init.go
@@ -369,11 +369,18 @@ func (o *InitOptions) persistConfiguration() error {
 	}
 
 	if !persistConfig {
-		log.Error("did not save config")
+		fmt.Fprintln(o.Out, "Did not save config")
 		return nil
 	}
 
 	log.WithField("path", o.ConfigPath).Info("writing config")
 
-	return config.Save(&o.Config, o.ConfigPath)
+	err = config.Save(&o.Config, o.ConfigPath)
+	if err != nil {
+		return err
+	}
+
+	fmt.Fprintln(o.Out, "Config saved")
+
+	return nil
 }

--- a/internal/cmd/repository.go
+++ b/internal/cmd/repository.go
@@ -15,10 +15,10 @@ func NewRepositoryCmd(streams cli.IOStreams) *cobra.Command {
 		Short:   "Manage repositories",
 	}
 
-	cmd.AddCommand(repository.NewAddCmd())
-	cmd.AddCommand(repository.NewCreateCmd())
+	cmd.AddCommand(repository.NewAddCmd(streams))
+	cmd.AddCommand(repository.NewCreateCmd(streams))
 	cmd.AddCommand(repository.NewListCmd(streams))
-	cmd.AddCommand(repository.NewRemoveCmd())
+	cmd.AddCommand(repository.NewRemoveCmd(streams))
 
 	return cmd
 }

--- a/internal/cmd/repository/add.go
+++ b/internal/cmd/repository/add.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/apex/log"
+	"github.com/martinohmann/kickoff/internal/cli"
 	"github.com/martinohmann/kickoff/internal/cmdutil"
 	"github.com/martinohmann/kickoff/internal/config"
 	"github.com/martinohmann/kickoff/internal/repository"
@@ -23,8 +24,10 @@ var (
 
 // NewAddCmd creates a new command for added a skeleton repository to the
 // kickoff config.
-func NewAddCmd() *cobra.Command {
-	o := &AddOptions{}
+func NewAddCmd(streams cli.IOStreams) *cobra.Command {
+	o := &AddOptions{
+		IOStreams: streams,
+	}
 
 	cmd := &cobra.Command{
 		Use:   "add <name> <url>",
@@ -57,6 +60,7 @@ func NewAddCmd() *cobra.Command {
 
 // AddOptions holds the options for the add command.
 type AddOptions struct {
+	cli.IOStreams
 	cmdutil.ConfigFlags
 
 	RepoName string
@@ -102,6 +106,8 @@ func (o *AddOptions) Run() error {
 		"name": o.RepoName,
 		"url":  o.RepoURL,
 	}).Info("repository added")
+
+	fmt.Fprintln(o.Out, "Repository added")
 
 	return nil
 }

--- a/internal/cmd/repository/create.go
+++ b/internal/cmd/repository/create.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"path/filepath"
 
+	"github.com/martinohmann/kickoff/internal/cli"
 	"github.com/martinohmann/kickoff/internal/cmdutil"
 	"github.com/martinohmann/kickoff/internal/config"
 	"github.com/martinohmann/kickoff/internal/file"
@@ -14,8 +15,11 @@ import (
 )
 
 // NewCreateCmd creates a command for creating a local skeleton repository.
-func NewCreateCmd() *cobra.Command {
-	o := &CreateOptions{SkeletonName: config.DefaultSkeletonName}
+func NewCreateCmd(streams cli.IOStreams) *cobra.Command {
+	o := &CreateOptions{
+		IOStreams:    streams,
+		SkeletonName: config.DefaultSkeletonName,
+	}
 
 	cmd := &cobra.Command{
 		Use:   "create <output-dir>",
@@ -52,6 +56,7 @@ func NewCreateCmd() *cobra.Command {
 
 // CreateOptions holds the options for the create command.
 type CreateOptions struct {
+	cli.IOStreams
 	OutputDir    string
 	SkeletonName string
 	Force        bool
@@ -98,5 +103,12 @@ func (o *CreateOptions) Validate() error {
 // Run creates a new skeleton repository in the provided output directory and
 // seeds it with a default skeleton.
 func (o *CreateOptions) Run() error {
-	return repository.Create(o.OutputDir, o.SkeletonName)
+	err := repository.Create(o.OutputDir, o.SkeletonName)
+	if err != nil {
+		return err
+	}
+
+	fmt.Fprintf(o.Out, "Created new skeleton repository in %s\n", o.OutputDir)
+
+	return nil
 }

--- a/internal/cmd/repository/remove.go
+++ b/internal/cmd/repository/remove.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/apex/log"
+	"github.com/martinohmann/kickoff/internal/cli"
 	"github.com/martinohmann/kickoff/internal/cmdutil"
 	"github.com/martinohmann/kickoff/internal/config"
 	"github.com/spf13/cobra"
@@ -11,8 +12,10 @@ import (
 
 // NewRemoveCmd creates a command for removing skeleton repositories from the
 // config.
-func NewRemoveCmd() *cobra.Command {
-	o := &RemoveOptions{}
+func NewRemoveCmd(streams cli.IOStreams) *cobra.Command {
+	o := &RemoveOptions{
+		IOStreams: streams,
+	}
 
 	cmd := &cobra.Command{
 		Use:     "remove <name>",
@@ -44,6 +47,7 @@ func NewRemoveCmd() *cobra.Command {
 
 // RemoveOptions holds the options for the remove command.
 type RemoveOptions struct {
+	cli.IOStreams
 	cmdutil.ConfigFlags
 
 	RepoName string
@@ -80,6 +84,8 @@ func (o *RemoveOptions) Run() error {
 	}
 
 	log.WithField("name", o.RepoName).Info("repository removed")
+
+	fmt.Fprintln(o.Out, "Repository removed")
 
 	return nil
 }

--- a/internal/cmd/skeleton.go
+++ b/internal/cmd/skeleton.go
@@ -15,7 +15,7 @@ func NewSkeletonCmd(streams cli.IOStreams) *cobra.Command {
 		Short:   "Manage skeletons",
 	}
 
-	cmd.AddCommand(skeleton.NewCreateCmd())
+	cmd.AddCommand(skeleton.NewCreateCmd(streams))
 	cmd.AddCommand(skeleton.NewListCmd(streams))
 	cmd.AddCommand(skeleton.NewShowCmd(streams))
 

--- a/internal/cmd/skeleton/create.go
+++ b/internal/cmd/skeleton/create.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"path/filepath"
 
+	"github.com/martinohmann/kickoff/internal/cli"
 	"github.com/martinohmann/kickoff/internal/cmdutil"
 	"github.com/martinohmann/kickoff/internal/file"
 	"github.com/martinohmann/kickoff/internal/skeleton"
@@ -11,8 +12,10 @@ import (
 )
 
 // NewCreateCmd creates a command for creating project skeletons.
-func NewCreateCmd() *cobra.Command {
-	o := &CreateOptions{}
+func NewCreateCmd(streams cli.IOStreams) *cobra.Command {
+	o := &CreateOptions{
+		IOStreams: streams,
+	}
 
 	cmd := &cobra.Command{
 		Use:   "create <output-dir>",
@@ -48,6 +51,7 @@ func NewCreateCmd() *cobra.Command {
 
 // CreateOptions holds the options for the create command.
 type CreateOptions struct {
+	cli.IOStreams
 	OutputDir string
 	Force     bool
 }
@@ -88,5 +92,12 @@ func (o *CreateOptions) Validate() error {
 
 // Run creates a new project skeleton in the provided output directory.
 func (o *CreateOptions) Run() error {
-	return skeleton.Create(o.OutputDir)
+	err := skeleton.Create(o.OutputDir)
+	if err != nil {
+		return err
+	}
+
+	fmt.Fprintf(o.Out, "Created new skeleton in %s\n", o.OutputDir)
+
+	return nil
 }

--- a/internal/cmd/skeleton/create_test.go
+++ b/internal/cmd/skeleton/create_test.go
@@ -5,14 +5,15 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
-	"reflect"
 	"testing"
 
+	"github.com/martinohmann/kickoff/internal/cli"
 	"github.com/martinohmann/kickoff/internal/cmdutil"
+	"github.com/spf13/cobra"
 )
 
 func TestCreateCmd_Execute_EmptyOutputDir(t *testing.T) {
-	cmd := NewCreateCmd()
+	cmd := newCreateCmd()
 	cmd.SetArgs([]string{""})
 
 	err := cmd.Execute()
@@ -22,7 +23,7 @@ func TestCreateCmd_Execute_EmptyOutputDir(t *testing.T) {
 }
 
 func TestCreateCmd_Execute_DirExists(t *testing.T) {
-	cmd := NewCreateCmd()
+	cmd := newCreateCmd()
 	cmd.SetArgs([]string{"."})
 
 	dir, err := filepath.Abs(".")
@@ -33,7 +34,11 @@ func TestCreateCmd_Execute_DirExists(t *testing.T) {
 	expectedErr := fmt.Errorf("output dir %s already exists, add --force to overwrite", dir)
 
 	err = cmd.Execute()
-	if !reflect.DeepEqual(expectedErr, err) {
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+
+	if expectedErr.Error() != err.Error() {
 		t.Fatalf("expected error %v, got %v", expectedErr, err)
 	}
 }
@@ -47,7 +52,7 @@ func TestCreateCmd_Execute(t *testing.T) {
 
 	outputDir := filepath.Join(name, "myskeleton")
 
-	cmd := NewCreateCmd()
+	cmd := newCreateCmd()
 	cmd.SetArgs([]string{outputDir})
 
 	err = cmd.Execute()
@@ -65,7 +70,7 @@ func TestCreateCmd_Execute_Force(t *testing.T) {
 
 	outputDir := filepath.Join(name, "myskeleton")
 
-	cmd := NewCreateCmd()
+	cmd := newCreateCmd()
 	cmd.SetArgs([]string{outputDir})
 
 	err = cmd.Execute()
@@ -73,11 +78,16 @@ func TestCreateCmd_Execute_Force(t *testing.T) {
 		t.Fatalf("expected nil error, got %v", err)
 	}
 
-	cmd = NewCreateCmd()
+	cmd = newCreateCmd()
 	cmd.SetArgs([]string{outputDir, "--force"})
 
 	err = cmd.Execute()
 	if err != nil {
 		t.Fatalf("expected nil error, got %v", err)
 	}
+}
+
+func newCreateCmd() *cobra.Command {
+	streams, _, _, _ := cli.NewTestIOStreams()
+	return NewCreateCmd(streams)
 }

--- a/internal/cmdutil/flags.go
+++ b/internal/cmdutil/flags.go
@@ -78,7 +78,7 @@ func (f *ConfigFlags) Complete() (err error) {
 	loadConfig := f.ConfigPath != "" && (!f.allowMissingConfig || file.Exists(f.ConfigPath))
 
 	if loadConfig {
-		log.WithField("path", f.ConfigPath).Debugf("loading config file")
+		log.WithField("path", f.ConfigPath).Debug("loading config file")
 
 		err = f.Config.MergeFromFile(f.ConfigPath)
 		if err != nil {

--- a/internal/repository/create.go
+++ b/internal/repository/create.go
@@ -14,7 +14,7 @@ import (
 func Create(path, skeletonName string) error {
 	skeletonsDir := filepath.Join(path, "skeletons")
 
-	log.WithField("path", path).Info("creating skeleton repository")
+	log.WithField("path", path).Info("creating repository")
 
 	err := os.MkdirAll(skeletonsDir, 0755)
 	if err != nil {

--- a/internal/skeleton/create.go
+++ b/internal/skeleton/create.go
@@ -14,7 +14,7 @@ import (
 // example .kickoff.yaml and example README.md.skel as starter. Returns an
 // error if creating path or writing any of the files fails.
 func Create(path string) error {
-	log.WithField("path", path).Info("creating skeleton directory")
+	log.WithField("path", path).Info("creating directory")
 
 	err := os.MkdirAll(path, 0755)
 	if err != nil {
@@ -36,7 +36,7 @@ func writeFiles(dir string) error {
 		path := filepath.Join(dir, filename)
 		contents := fileTemplates[filename]
 
-		log.WithField("path", path).Infof("writing %s", filename)
+		log.WithField("path", path).Info("creating file")
 
 		err := ioutil.WriteFile(path, []byte(contents), 0644)
 		if err != nil {


### PR DESCRIPTION
The logger should only be used to for additional information that is
useful for debugging. Normal output should just go to stdout.

Changes log stmt to stdout messages where appropriate.

Also removed the `--verbose` flag and replaces it with the `--log-level`
flag to allow more fine grained control over the log output.