### PR TITLE
fix(errors): fix error wrapping

### DIFF
--- a/internal/cmd/cache/clean.go
+++ b/internal/cmd/cache/clean.go
@@ -26,7 +26,7 @@ func NewCleanCmd(streams cli.IOStreams) *cobra.Command {
 
 			err := os.RemoveAll(cacheDir)
 			if err != nil {
-				return fmt.Errorf("failed to clean cache: %v", err)
+				return fmt.Errorf("failed to clean cache: %w", err)
 			}
 
 			fmt.Fprintln(streams.Out, "Cache cleaned")

--- a/internal/cmd/config/edit.go
+++ b/internal/cmd/config/edit.go
@@ -100,7 +100,7 @@ func (o *EditOptions) Run() (err error) {
 
 	tmpf, err := ioutil.TempFile("", "kickoff-*.yaml")
 	if err != nil {
-		return fmt.Errorf("failed to create temporary file: %v", err)
+		return fmt.Errorf("failed to create temporary file: %w", err)
 	}
 
 	tmpfilePath := tmpf.Name()
@@ -126,14 +126,14 @@ func (o *EditOptions) Run() (err error) {
 	// consider it invalid and abort without copying it back.
 	cfg, err := config.Load(tmpfilePath)
 	if err != nil {
-		return fmt.Errorf("not saving invalid kickoff config: %v", err)
+		return fmt.Errorf("not saving invalid kickoff config: %w", err)
 	}
 
 	log.WithField("config", o.ConfigPath).Info("writing config")
 
 	err = config.Save(&cfg, o.ConfigPath)
 	if err != nil {
-		return fmt.Errorf("error while saving config file: %v", err)
+		return fmt.Errorf("error while saving config file: %w", err)
 	}
 
 	fmt.Fprintln(o.Out, "Config saved")
@@ -155,7 +155,7 @@ func launchEditor(path string) error {
 
 	err := cmd.Run()
 	if err != nil {
-		return fmt.Errorf("error while launching editor command %q: %v", commandLine, err)
+		return fmt.Errorf("error while launching editor command %q: %w", commandLine, err)
 	}
 
 	return nil

--- a/internal/cmd/repository/add.go
+++ b/internal/cmd/repository/add.go
@@ -92,7 +92,7 @@ func (o *AddOptions) Validate() error {
 func (o *AddOptions) Run() error {
 	_, err := repository.ParseURL(o.RepoURL)
 	if err != nil {
-		return fmt.Errorf("failed to parse repository URL: %v", err)
+		return fmt.Errorf("failed to parse repository URL: %w", err)
 	}
 
 	o.Repositories[o.RepoName] = o.RepoURL

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -80,7 +80,7 @@ func (c *Config) ApplyDefaults() {
 func (c *Config) MergeFromFile(path string) error {
 	config, err := Load(path)
 	if err != nil {
-		return fmt.Errorf("failed to load config: %v", err)
+		return fmt.Errorf("failed to load config: %w", err)
 	}
 
 	return mergo.Merge(c, config)

--- a/internal/license/license.go
+++ b/internal/license/license.go
@@ -70,8 +70,8 @@ func (c *Client) GetLicense(ctx context.Context, name string) (*Info, error) {
 
 	license, _, err := c.Get(ctx, name)
 	if err != nil {
-		errResp, ok := err.(*github.ErrorResponse)
-		if ok && errResp.Response.StatusCode == 404 {
+		var errResp *github.ErrorResponse
+		if errors.As(err, &errResp) && errResp.Response.StatusCode == 404 {
 			return nil, ErrNotFound
 		}
 

--- a/internal/project/project.go
+++ b/internal/project/project.go
@@ -268,7 +268,7 @@ func (p *Project) makeDestination(f Source, values template.Values) (Destination
 
 	targetFilename, err := template.Render(srcFilename, values)
 	if err != nil {
-		return Destination{}, fmt.Errorf("failed to resolve templated filename %q: %v", srcFilename, err)
+		return Destination{}, fmt.Errorf("failed to resolve templated filename %q: %w", srcFilename, err)
 	}
 
 	if len(targetFilename) == 0 {

--- a/internal/project/project_test.go
+++ b/internal/project/project_test.go
@@ -200,7 +200,7 @@ func TestCreate(t *testing.T) {
 			_, err = Create(skeleton, tmpdir, test.config)
 			if test.expectedErr != nil {
 				require.Error(t, err)
-				assert.Equal(t, test.expectedErr, err)
+				assert.EqualError(t, err, test.expectedErr.Error())
 			} else {
 				require.NoError(t, err)
 			}

--- a/internal/repository/load.go
+++ b/internal/repository/load.go
@@ -42,7 +42,7 @@ func LoadSkeleton(ctx context.Context, repo Repository, name string) (*skeleton.
 
 	s, err := loadSkeleton(ctx, info, visits)
 	if err != nil {
-		return nil, fmt.Errorf("failed to load skeleton: %v", err)
+		return nil, fmt.Errorf("failed to load skeleton: %w", err)
 	}
 
 	return s, nil
@@ -54,7 +54,7 @@ func LoadSkeleton(ctx context.Context, repo Repository, name string) (*skeleton.
 func loadSkeleton(ctx context.Context, info *skeleton.Info, visits map[skeleton.Reference]struct{}) (*skeleton.Skeleton, error) {
 	config, err := info.LoadConfig()
 	if err != nil {
-		return nil, fmt.Errorf("failed to load skeleton config: %v", err)
+		return nil, fmt.Errorf("failed to load skeleton config: %w", err)
 	}
 
 	files, err := collectFiles(info)

--- a/internal/repository/local.go
+++ b/internal/repository/local.go
@@ -53,7 +53,7 @@ func (r *LocalRepository) GetSkeleton(ctx context.Context, name string) (*skelet
 func (r *LocalRepository) ListSkeletons(ctx context.Context) ([]*skeleton.Info, error) {
 	infos, err := r.info.FindSkeletons()
 	if err != nil {
-		return nil, fmt.Errorf("failed to list skeletons: %v", err)
+		return nil, fmt.Errorf("failed to list skeletons: %w", err)
 	}
 
 	return infos, nil

--- a/internal/repository/multi.go
+++ b/internal/repository/multi.go
@@ -2,6 +2,7 @@ package repository
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sort"
 	"strings"
@@ -102,11 +103,14 @@ func (r *MultiRepository) findSkeleton(ctx context.Context, name string) (*skele
 		repo := r.repoMap[repoName]
 
 		skeleton, err := repo.GetSkeleton(ctx, name)
-		if _, ok := err.(SkeletonNotFoundError); ok {
-			// Ignore the error, we will return an error only if the skeleton
-			// was not found in any of the repositories.
-			continue
-		} else if err != nil {
+		if err != nil {
+			var notFoundErr SkeletonNotFoundError
+			if errors.As(err, &notFoundErr) {
+				// Ignore the error, we will return an error only if the skeleton
+				// was not found in any of the repositories.
+				continue
+			}
+
 			return nil, err
 		}
 

--- a/internal/repository/multi_test.go
+++ b/internal/repository/multi_test.go
@@ -2,6 +2,7 @@ package repository
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -81,7 +82,8 @@ func TestMultiRepository_GetSkeleton(t *testing.T) {
 		_, err = repo.GetSkeleton(context.Background(), "nonexistent")
 		require.Error(t, err)
 
-		if _, ok := err.(SkeletonNotFoundError); ok {
+		var notFoundErr SkeletonNotFoundError
+		if errors.As(err, &notFoundErr) {
 			t.Fatal("expected an error different from SkeletonNotFoundError")
 		}
 	})

--- a/internal/repository/repo.go
+++ b/internal/repository/repo.go
@@ -79,7 +79,7 @@ func NewNamed(name, url string) (repo Repository, err error) {
 func ParseURL(rawurl string) (*skeleton.RepoInfo, error) {
 	u, err := url.Parse(rawurl)
 	if err != nil {
-		return nil, fmt.Errorf("invalid repo URL %q: %v", rawurl, err)
+		return nil, fmt.Errorf("invalid repo URL %q: %w", rawurl, err)
 	}
 
 	if u.Host == "" {
@@ -93,7 +93,7 @@ func ParseURL(rawurl string) (*skeleton.RepoInfo, error) {
 
 	query, err := url.ParseQuery(u.RawQuery)
 	if err != nil {
-		return nil, fmt.Errorf("invalid URL query %q: %v", u.RawQuery, err)
+		return nil, fmt.Errorf("invalid URL query %q: %w", u.RawQuery, err)
 	}
 
 	var revision string

--- a/internal/skeleton/create.go
+++ b/internal/skeleton/create.go
@@ -40,7 +40,7 @@ func writeFiles(dir string) error {
 
 		err := ioutil.WriteFile(path, []byte(contents), 0644)
 		if err != nil {
-			return fmt.Errorf("failed to write skeleton file: %v", err)
+			return fmt.Errorf("failed to write skeleton file: %w", err)
 		}
 	}
 

--- a/internal/skeleton/skeleton.go
+++ b/internal/skeleton/skeleton.go
@@ -127,7 +127,7 @@ func Merge(skeletons ...*Skeleton) (*Skeleton, error) {
 func merge(lhs, rhs *Skeleton) (*Skeleton, error) {
 	values, err := template.MergeValues(lhs.Values, rhs.Values)
 	if err != nil {
-		return nil, fmt.Errorf("failed to merge skeleton %s and %s: %v", lhs.Info, rhs.Info, err)
+		return nil, fmt.Errorf("failed to merge skeleton %s and %s: %w", lhs.Info, rhs.Info, err)
 	}
 
 	s := &Skeleton{
@@ -207,7 +207,7 @@ func FindSkeletonDir(path string) (string, error) {
 // is a skeleton dir itself, this will return false.
 func IsInsideSkeletonDir(path string) (bool, error) {
 	dir, err := FindSkeletonDir(path)
-	if err == ErrDirNotFound {
+	if errors.Is(err, ErrDirNotFound) {
 		return false, nil
 	} else if err != nil {
 		return false, err

--- a/internal/template/render.go
+++ b/internal/template/render.go
@@ -16,7 +16,7 @@ import (
 func Render(templateText string, data interface{}) (string, error) {
 	tpl, err := newTemplate("").Parse(templateText)
 	if err != nil {
-		return "", fmt.Errorf("failed to prepare template: %v", err)
+		return "", fmt.Errorf("failed to prepare template: %w", err)
 	}
 
 	return execute(tpl, data)
@@ -44,7 +44,7 @@ func execute(tpl *template.Template, data interface{}) (string, error) {
 
 	err := tpl.Execute(&buf, data)
 	if err != nil {
-		return "", fmt.Errorf("failed to render template: %v", err)
+		return "", fmt.Errorf("failed to render template: %w", err)
 	}
 
 	return buf.String(), nil


### PR DESCRIPTION
- replace %v with %w in wrapped errors
- use `errors.As` instead of type assertions
- use `errors.Is` instead of `==`