### PR TITLE
fix: do not treat absent default config as error

### DIFF
--- a/internal/cmd/init.go
+++ b/internal/cmd/init.go
@@ -44,7 +44,6 @@ func NewInitCmd(streams cli.IOStreams) *cobra.Command {
 		},
 	}
 
-	o.AllowMissingConfig()
 	o.TimeoutFlag.AddFlag(cmd)
 	cmdutil.AddConfigFlag(cmd, &o.ConfigPath)
 

--- a/internal/kickoff/config.go
+++ b/internal/kickoff/config.go
@@ -146,6 +146,8 @@ func SaveConfig(path string, config *Config) error {
 // Load loads a file from path into v. Returns an error if reading the file
 // fails. Does not perform any defaulting or validation.
 func Load(path string, v interface{}) error {
+	log.WithField("path", path).Debug("loading file")
+
 	buf, err := ioutil.ReadFile(path)
 	if err != nil {
 		return err
@@ -156,6 +158,8 @@ func Load(path string, v interface{}) error {
 
 // Save saves v to path.
 func Save(path string, v interface{}) error {
+	log.WithField("path", path).Debug("saving file")
+
 	buf, err := yaml.Marshal(v)
 	if err != nil {
 		return err


### PR DESCRIPTION
Fixes #86

No tests added as the underlying logic will be rewritten soon.