### PR TITLE
feat: improve skeleton creation

### DIFF
--- a/docs/skeletons.md
+++ b/docs/skeletons.md
@@ -26,7 +26,7 @@ more](/skeletons/structure) about skeleton directory structure.
 Project skeletons can be created with kickoff very easily:
 
 ```bash
-$ kickoff skeleton create ~/kickoff-skeletons/skeletons/myskeleton
+$ kickoff skeleton create myrepo myskeleton
 ```
 
 However, there is more to it. Check out the [Creating project


### PR DESCRIPTION
The `kickoff skeleton create` command now accepts the name of a local
repo and the skeleton name instead of a path.

Closes #85 