### PR TITLE
refactor: add kickoff.(*RepoRef).LocalPath() and use it

### DIFF
--- a/internal/cmd/init.go
+++ b/internal/cmd/init.go
@@ -303,7 +303,7 @@ func (o *InitOptions) configureDefaultSkeletonRepository() error {
 		return nil
 	}
 
-	localPath := ref.Path
+	localPath := ref.LocalPath()
 
 	if file.Exists(localPath) {
 		return nil

--- a/internal/cmd/repository/list.go
+++ b/internal/cmd/repository/list.go
@@ -78,12 +78,12 @@ func (o *ListOptions) Run() error {
 			}
 		}
 
-		path, err := homedir.Collapse(ref.Path)
+		localPath, err := homedir.Collapse(ref.LocalPath())
 		if err != nil {
 			return err
 		}
 
-		tw.Append(name, typ, path, url, revision)
+		tw.Append(name, typ, localPath, url, revision)
 	}
 
 	tw.Render()

--- a/internal/cmd/repository/remove.go
+++ b/internal/cmd/repository/remove.go
@@ -84,16 +84,18 @@ func (o *RemoveOptions) Run() error {
 	}
 
 	if repoRef.IsRemote() {
+		localPath := repoRef.LocalPath()
+
 		// Prevent removal of anything outside of the local user cache dir.
 		// Remote repos should never ever reside outside of the user cache dir.
 		// If they do this is a programmer error.
-		if !strings.HasPrefix(repoRef.Path, kickoff.LocalRepositoryCacheDir) {
-			log.WithField("path", repoRef.Path).Fatal("found remote repository cache outside of user cache dir, refusing to delete")
+		if !strings.HasPrefix(localPath, kickoff.LocalRepositoryCacheDir) {
+			log.WithField("path", localPath).Fatal("found remote repository cache outside of user cache dir, refusing to delete")
 		}
 
-		log.WithField("path", repoRef.Path).Debug("deleting repository cache dir")
+		log.WithField("path", localPath).Debug("deleting repository cache dir")
 
-		if err := os.RemoveAll(repoRef.Path); err != nil {
+		if err := os.RemoveAll(localPath); err != nil {
 			return fmt.Errorf("failed to delete repository cache dir: %w", err)
 		}
 	}

--- a/internal/cmd/skeleton/create.go
+++ b/internal/cmd/skeleton/create.go
@@ -3,7 +3,6 @@ package skeleton
 import (
 	"errors"
 	"fmt"
-	"path/filepath"
 
 	"github.com/martinohmann/kickoff/internal/cli"
 	"github.com/martinohmann/kickoff/internal/cmdutil"
@@ -90,13 +89,13 @@ func (o *CreateOptions) Run() error {
 		return fmt.Errorf("repository %q is remote. skeletons can only be created in local repositories", o.RepoName)
 	}
 
-	skeletonDir := filepath.Join(repoRef.Path, kickoff.SkeletonsDir, o.SkeletonName)
+	skeletonPath := repoRef.SkeletonPath(o.SkeletonName)
 
-	if file.Exists(skeletonDir) {
+	if file.Exists(skeletonPath) {
 		return fmt.Errorf("skeleton %q already exists in repository %q", o.SkeletonName, o.RepoName)
 	}
 
-	err = skeleton.Create(skeletonDir)
+	err = skeleton.Create(skeletonPath)
 	if err != nil {
 		return err
 	}

--- a/internal/repository/local.go
+++ b/internal/repository/local.go
@@ -22,20 +22,13 @@ type localRepository struct {
 
 // newLocal creates a *localRepository from ref. Returns an error if
 // resolving the absolute path to the skeleton repository fails.
-func newLocal(ref kickoff.RepoRef) (*localRepository, error) {
-	var err error
-
-	ref.Path, err = filepath.Abs(ref.Path)
-	if err != nil {
-		return nil, err
-	}
-
-	return &localRepository{ref: ref}, nil
+func newLocal(ref kickoff.RepoRef) *localRepository {
+	return &localRepository{ref: ref}
 }
 
 // GetSkeleton implements kickoff.Repository.
 func (r *localRepository) GetSkeleton(ctx context.Context, name string) (*kickoff.SkeletonRef, error) {
-	path := filepath.Join(r.ref.Path, kickoff.SkeletonsDir, name)
+	path := r.ref.SkeletonPath(name)
 
 	ok, err := skeleton.IsSkeletonDir(path)
 	if err != nil {
@@ -57,7 +50,7 @@ func (r *localRepository) GetSkeleton(ctx context.Context, name string) (*kickof
 
 // ListSkeletons implements kickoff.Repository.
 func (r *localRepository) ListSkeletons(ctx context.Context) ([]*kickoff.SkeletonRef, error) {
-	infos, err := findSkeletons(&r.ref, filepath.Join(r.ref.Path, kickoff.SkeletonsDir))
+	infos, err := findSkeletons(&r.ref, r.ref.SkeletonsPath())
 	if err != nil {
 		return nil, fmt.Errorf("failed to list skeletons: %w", err)
 	}

--- a/internal/repository/repo.go
+++ b/internal/repository/repo.go
@@ -42,11 +42,15 @@ func NewFromRef(ref kickoff.RepoRef) (kickoff.Repository, error) {
 }
 
 func newFromRef(ref kickoff.RepoRef) (kickoff.Repository, error) {
+	if err := ref.Validate(); err != nil {
+		return nil, err
+	}
+
 	if ref.IsRemote() {
 		return newRemote(ref)
 	}
 
-	return newLocal(ref)
+	return newLocal(ref), nil
 }
 
 // NewFromMap creates a kickoff.Repository which aggregates the

--- a/internal/repository/repo_test.go
+++ b/internal/repository/repo_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/martinohmann/kickoff/internal/kickoff"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -73,4 +74,11 @@ func TestNewNamed(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, "the-name", info.Repo.Name)
 	})
+}
+
+func TestNewFromRef_Invalid(t *testing.T) {
+	invalidRef := kickoff.RepoRef{Path: "/foo/bar", URL: "https://foo.bar.baz"}
+
+	_, err := NewFromRef(invalidRef)
+	require.EqualError(t, err, "invalid repository ref: URL and Path must not be set at the same time")
 }

--- a/internal/testdata/repos/advanced/skeletons/childofchild/.kickoff.yaml
+++ b/internal/testdata/repos/advanced/skeletons/childofchild/.kickoff.yaml
@@ -1,4 +1,3 @@
 ---
 parent:
-  repositoryURL: ../..
   skeletonName: child

--- a/internal/testdata/repos/advanced/skeletons/cyclea/.kickoff.yaml
+++ b/internal/testdata/repos/advanced/skeletons/cyclea/.kickoff.yaml
@@ -1,4 +1,3 @@
 ---
 parent:
-  repositoryURL: ../..
   skeletonName: cycleb

--- a/internal/testdata/repos/advanced/skeletons/cycleb/.kickoff.yaml
+++ b/internal/testdata/repos/advanced/skeletons/cycleb/.kickoff.yaml
@@ -1,4 +1,3 @@
 ---
 parent:
-  repositoryURL: ../..
   skeletonName: cyclec

--- a/internal/testdata/repos/advanced/skeletons/cyclec/.kickoff.yaml
+++ b/internal/testdata/repos/advanced/skeletons/cyclec/.kickoff.yaml
@@ -1,4 +1,3 @@
 ---
 parent:
-  repositoryURL: ../..
   skeletonName: cyclea

--- a/internal/testutil/dirs.go
+++ b/internal/testutil/dirs.go
@@ -1,0 +1,18 @@
+package testutil
+
+import (
+	"github.com/martinohmann/kickoff/internal/kickoff"
+)
+
+// MockRepositoryCacheDir changes the global repository cache dir to a
+// temporary directory and returns a func to restore it.
+//
+// Usage example in tests:
+//
+//   defer testutil.MockRepositoryCacheDir(t.TempDir())()
+//
+func MockRepositoryCacheDir(dir string) func() {
+	oldCacheDir := kickoff.LocalRepositoryCacheDir
+	kickoff.LocalRepositoryCacheDir = dir
+	return func() { kickoff.LocalRepositoryCacheDir = oldCacheDir }
+}


### PR DESCRIPTION
LocalPath() always returns a valid local path for a skeleton no matter
if it is local or remote. Populating the Path and URL field at the same
time now is an error.