### PR TITLE
feat: panic on homedir errors

### DIFF
--- a/internal/cmd/project/create.go
+++ b/internal/cmd/project/create.go
@@ -291,10 +291,7 @@ func (o *CreateOptions) createProject(ctx context.Context, s *kickoff.Skeleton) 
 		config.Filesystem = afero.NewMemMapFs()
 	}
 
-	outputDir, err := homedir.Collapse(o.OutputDir)
-	if err != nil {
-		return err
-	}
+	outputDir := homedir.MustCollapse(o.OutputDir)
 
 	fmt.Fprintf(o.Out, "Creating project in %s.\n\n", colorBold.Sprint(outputDir))
 

--- a/internal/cmd/repository/list.go
+++ b/internal/cmd/repository/list.go
@@ -78,10 +78,7 @@ func (o *ListOptions) Run() error {
 			}
 		}
 
-		localPath, err := homedir.Collapse(ref.LocalPath())
-		if err != nil {
-			return err
-		}
+		localPath := homedir.MustCollapse(ref.LocalPath())
 
 		tw.Append(name, typ, localPath, url, revision)
 	}

--- a/internal/cmd/repository/remove.go
+++ b/internal/cmd/repository/remove.go
@@ -90,7 +90,8 @@ func (o *RemoveOptions) Run() error {
 		// Remote repos should never ever reside outside of the user cache dir.
 		// If they do this is a programmer error.
 		if !strings.HasPrefix(localPath, kickoff.LocalRepositoryCacheDir) {
-			log.WithField("path", localPath).Fatal("found remote repository cache outside of user cache dir, refusing to delete")
+			log.WithField("path", localPath).
+				Panic("unexpected repository location: found remote repository cache outside of user cache dir, refusing to delete")
 		}
 
 		log.WithField("path", localPath).Debug("deleting repository cache dir")

--- a/internal/cmd/skeleton/list.go
+++ b/internal/cmd/skeleton/list.go
@@ -67,10 +67,7 @@ func (o *ListOptions) Run() error {
 	tw.SetHeader("RepoName", "Name", "Path")
 
 	for _, skeleton := range skeletons {
-		path, err := homedir.Collapse(skeleton.Path)
-		if err != nil {
-			return err
-		}
+		path := homedir.MustCollapse(skeleton.Path)
 
 		tw.Append(skeleton.Repo.Name, skeleton.Name, path)
 	}

--- a/internal/cmd/skeleton/show.go
+++ b/internal/cmd/skeleton/show.go
@@ -96,10 +96,7 @@ func (o *ShowOptions) Run() error {
 	default:
 		tw := cli.NewTableWriter(o.Out)
 
-		path, err := homedir.Collapse(skeleton.Ref.Path)
-		if err != nil {
-			return err
-		}
+		path := homedir.MustCollapse(skeleton.Ref.Path)
 
 		repoInfo := skeleton.Ref.Repo
 
@@ -123,12 +120,9 @@ func (o *ShowOptions) Run() error {
 		}
 
 		if skeleton.Parent != nil {
-			parent, err := homedir.Collapse(skeleton.Parent.Ref.Path)
-			if err != nil {
-				return err
-			}
+			parentPath := homedir.MustCollapse(skeleton.Parent.Ref.Path)
 
-			tw.Append("Parent", parent)
+			tw.Append("Parent", parentPath)
 		}
 
 		if len(skeleton.Values) > 0 {

--- a/internal/homedir/homedir.go
+++ b/internal/homedir/homedir.go
@@ -7,7 +7,8 @@ import (
 	"path/filepath"
 	"strings"
 
-	homedir "github.com/mitchellh/go-homedir"
+	"github.com/mitchellh/go-homedir"
+	log "github.com/sirupsen/logrus"
 )
 
 // Collapse replaces the homedir in absolute paths with `~`. E.g.
@@ -36,9 +37,31 @@ func Collapse(path string) (string, error) {
 	return fmt.Sprintf("~/%s", strings.TrimLeft(unprefixed, "/")), nil
 }
 
+// MustCollapse is the same as Collapse but will panic on errors while
+// attempting to collapse the home directory.
+func MustCollapse(path string) string {
+	path, err := Collapse(path)
+	if err != nil {
+		log.WithError(err).Panic("failed to collapse homedir")
+	}
+
+	return path
+}
+
 // Expand expands the path to include the home directory if the path
 // is prefixed with `~`. If it isn't prefixed with `~`, the path is
 // returned as-is.
 func Expand(path string) (string, error) {
 	return homedir.Expand(path)
+}
+
+// MustExpand is the same as Expand but will panic on errors while attempting
+// to expand the home directory.
+func MustExpand(path string) string {
+	path, err := Expand(path)
+	if err != nil {
+		log.WithError(err).Panic("failed to expand homedir")
+	}
+
+	return path
 }

--- a/internal/kickoff/repository.go
+++ b/internal/kickoff/repository.go
@@ -80,7 +80,7 @@ func (r *RepoRef) LocalPath() string {
 	if err != nil {
 		log.WithError(err).
 			WithField("name", r.Name).
-			Fatal("failed to determine local path for repository")
+			Panic("failed to determine local path for repository")
 	}
 
 	return localPath
@@ -124,12 +124,7 @@ func ParseRepoRef(rawurl string) (*RepoRef, error) {
 	}
 
 	if u.Host == "" {
-		path, err := homedir.Expand(u.Path)
-		if err != nil {
-			return nil, err
-		}
-
-		return &RepoRef{Path: path}, nil
+		return &RepoRef{Path: homedir.MustExpand(u.Path)}, nil
 	}
 
 	query, err := url.ParseQuery(u.RawQuery)


### PR DESCRIPTION
A failure to lookup the homedir of the user cannot be handled properly
as this is most likely an issue with the user's system. We better panic
with a stack trace instead.