### PR TITLE
feat: use repo's default branch if revision is omitted

### DIFF
--- a/internal/cmd/repository/list.go
+++ b/internal/cmd/repository/list.go
@@ -72,6 +72,7 @@ func (o *ListOptions) Run() error {
 		if ref.IsRemote() {
 			url = ref.URL
 			typ = "remote"
+			revision = "<default-branch>"
 
 			if ref.Revision != "" {
 				revision = ref.Revision

--- a/internal/kickoff/repository.go
+++ b/internal/kickoff/repository.go
@@ -134,10 +134,6 @@ func ParseRepoRef(rawurl string) (*RepoRef, error) {
 		revision = rev[0]
 	}
 
-	if revision == "" {
-		revision = "master"
-	}
-
 	// Query is only used to pass an optional revision and needs to be empty in
 	// the final repository URL.
 	u.RawQuery = ""

--- a/internal/kickoff/repository_test.go
+++ b/internal/kickoff/repository_test.go
@@ -49,8 +49,7 @@ func TestParseRepoRef(t *testing.T) {
 			name: "url",
 			s:    "https://foo.bar.baz/johndoe/repo",
 			expected: &RepoRef{
-				URL:      "https://foo.bar.baz/johndoe/repo",
-				Revision: "master",
+				URL: "https://foo.bar.baz/johndoe/repo",
 			},
 		},
 		{
@@ -65,8 +64,7 @@ func TestParseRepoRef(t *testing.T) {
 			name: "git url",
 			s:    "git://git@github.com/martinohmann/kickoff.git",
 			expected: &RepoRef{
-				URL:      "git://git@github.com/martinohmann/kickoff.git",
-				Revision: "master",
+				URL: "git://git@github.com/martinohmann/kickoff.git",
 			},
 		},
 		{

--- a/internal/repository/load_test.go
+++ b/internal/repository/load_test.go
@@ -90,7 +90,7 @@ func TestGetParentRepoRef(t *testing.T) {
 		{
 			name:      "remote parent repository",
 			repoRef:   &kickoff.RepoRef{Name: "foo", Path: "/tmp/foo"},
-			parentRef: kickoff.ParentRef{RepositoryURL: "https://foo.bar.baz"},
+			parentRef: kickoff.ParentRef{RepositoryURL: "https://foo.bar.baz?revision=master"},
 			expected:  &kickoff.RepoRef{URL: "https://foo.bar.baz", Revision: "master"},
 		},
 		{

--- a/internal/repository/remote.go
+++ b/internal/repository/remote.go
@@ -133,6 +133,10 @@ func (r *remoteRepository) updateLocalCache(ctx context.Context, url, revision s
 		return err
 	}
 
+	if revision == "" {
+		return nil
+	}
+
 	return checkoutRevision(repo, revision)
 }
 


### PR DESCRIPTION
Until now, the `master` branch was picked if no revision was specified.
Since lots of git hosting platforms switched the default to `main` it
makes sense to not default to master anymore.

Instead, just clone the repo (which will checkout the default branch)
and do not attempt to checkout a revision.