### PR TITLE
refactor(cmds)!: cleanup commands

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -4,7 +4,7 @@ run:
 
 linters-settings:
   errcheck:
-    ignore: fmt:[FS]?[Pp]rint*,github.com/spf13/cobra:Mark*
+    ignore: fmt:[FS]?[Pp]rint*,github.com/spf13/cobra:(Mark|RegisterFlagCompletionFunc)
 
 issues:
   exclude-rules:

--- a/internal/cmd/cache/clean.go
+++ b/internal/cmd/cache/clean.go
@@ -4,9 +4,9 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/kirsle/configdir"
 	"github.com/martinohmann/kickoff/internal/cli"
 	"github.com/martinohmann/kickoff/internal/cmdutil"
+	"github.com/martinohmann/kickoff/internal/kickoff"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
@@ -20,11 +20,9 @@ func NewCleanCmd(streams cli.IOStreams) *cobra.Command {
 			Cleans kickoff's local cache of remote skeleton repositories.`),
 		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			cacheDir := configdir.LocalCache("kickoff")
+			log.WithField("cache.dir", kickoff.LocalCacheDir).Info("cleaning cache")
 
-			log.WithField("cache.dir", cacheDir).Info("cleaning cache")
-
-			err := os.RemoveAll(cacheDir)
+			err := os.RemoveAll(kickoff.LocalCacheDir)
 			if err != nil {
 				return fmt.Errorf("failed to clean cache: %w", err)
 			}

--- a/internal/cmd/config/edit.go
+++ b/internal/cmd/config/edit.go
@@ -5,7 +5,6 @@ import (
 	"io/ioutil"
 	"os"
 	"os/exec"
-	"path/filepath"
 	"strings"
 
 	"github.com/ghodss/yaml"
@@ -61,22 +60,6 @@ func NewEditCmd(streams cli.IOStreams) *cobra.Command {
 type EditOptions struct {
 	cli.IOStreams
 	cmdutil.ConfigFlags
-}
-
-// Complete completes the command options.
-func (o *EditOptions) Complete() (err error) {
-	err = o.ConfigFlags.Complete()
-	if err != nil {
-		return err
-	}
-
-	if o.ConfigPath == "" {
-		o.ConfigPath = kickoff.DefaultConfigPath
-	}
-
-	o.ConfigPath, err = filepath.Abs(o.ConfigPath)
-
-	return err
 }
 
 // Run loads the config file using the configured editor. The config file is

--- a/internal/cmd/config/show_test.go
+++ b/internal/cmd/config/show_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 
 	"github.com/martinohmann/kickoff/internal/cli"
-	"github.com/martinohmann/kickoff/internal/cmdutil"
 	"github.com/martinohmann/kickoff/internal/template"
 	"github.com/martinohmann/kickoff/internal/testutil"
 	"github.com/stretchr/testify/assert"
@@ -27,7 +26,6 @@ func TestShowCmd_Execute_InvalidOutput(t *testing.T) {
 
 	err := cmd.Execute()
 	require.Error(t, err)
-	assert.Equal(t, cmdutil.ErrInvalidOutputFormat, err)
 }
 
 func TestShowCmd_Execute(t *testing.T) {

--- a/internal/cmd/init.go
+++ b/internal/cmd/init.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"fmt"
-	"path/filepath"
 	"strings"
 
 	survey "github.com/AlecAivazis/survey/v2"
@@ -35,8 +34,7 @@ func NewInitCmd(streams cli.IOStreams) *cobra.Command {
 		`),
 		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			err := o.Complete()
-			if err != nil {
+			if err := o.Complete(); err != nil {
 				return err
 			}
 
@@ -61,18 +59,8 @@ type InitOptions struct {
 }
 
 // Complete completes the command options.
-func (o *InitOptions) Complete() (err error) {
-	err = o.ConfigFlags.Complete()
-	if err != nil {
-		return err
-	}
-
-	if o.ConfigPath == "" {
-		o.ConfigPath = kickoff.DefaultConfigPath
-	}
-
-	o.ConfigPath, err = filepath.Abs(o.ConfigPath)
-	if err != nil {
+func (o *InitOptions) Complete() error {
+	if err := o.ConfigFlags.Complete(); err != nil {
 		return err
 	}
 
@@ -81,7 +69,7 @@ func (o *InitOptions) Complete() (err error) {
 	o.GitignoreClient = gitignore.NewClient(httpClient)
 	o.LicenseClient = license.NewClient(httpClient)
 
-	return
+	return nil
 }
 
 // Run runs the interactive configuration of kickoff.

--- a/internal/cmd/repository/create.go
+++ b/internal/cmd/repository/create.go
@@ -1,7 +1,6 @@
 package repository
 
 import (
-	"errors"
 	"fmt"
 	"path/filepath"
 
@@ -30,7 +29,7 @@ func NewCreateCmd(streams cli.IOStreams) *cobra.Command {
 
             # Create a new repository
 			kickoff repository create myrepo /repository/output/path`),
-		Args: cobra.ExactArgs(2),
+		Args: cmdutil.ExactNonEmptyArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if err := o.Complete(args); err != nil {
 				return err
@@ -56,8 +55,9 @@ func NewCreateCmd(streams cli.IOStreams) *cobra.Command {
 type CreateOptions struct {
 	cli.IOStreams
 	cmdutil.ConfigFlags
+
 	RepoName     string
-	OutputDir    string
+	RepoDir      string
 	SkeletonName string
 }
 
@@ -65,7 +65,7 @@ type CreateOptions struct {
 func (o *CreateOptions) Complete(args []string) (err error) {
 	o.RepoName = args[0]
 
-	o.OutputDir, err = filepath.Abs(args[1])
+	o.RepoDir, err = filepath.Abs(args[1])
 	if err != nil {
 		return err
 	}
@@ -75,37 +75,29 @@ func (o *CreateOptions) Complete(args []string) (err error) {
 
 // Validate validates the create options.
 func (o *CreateOptions) Validate() error {
-	if o.RepoName == "" {
-		return errors.New("repository name must not be empty")
-	}
-
-	if o.SkeletonName == "" {
-		return errors.New("--skeleton-name must not be empty")
-	}
-
 	if _, ok := o.Repositories[o.RepoName]; ok {
-		return fmt.Errorf("repository with name %q already exists", o.RepoName)
+		return cmdutil.RepositoryAlreadyExistsError(o.RepoName)
 	}
 
-	return o.ConfigFlags.Validate()
+	return nil
 }
 
 // Run creates a new skeleton repository in the provided output directory and
 // seeds it with a default skeleton.
 func (o *CreateOptions) Run() error {
-	err := repository.CreateWithSkeleton(o.OutputDir, o.SkeletonName)
+	err := repository.CreateWithSkeleton(o.RepoDir, o.SkeletonName)
 	if err != nil {
 		return err
 	}
 
-	o.Repositories[o.RepoName] = o.OutputDir
+	o.Repositories[o.RepoName] = o.RepoDir
 
 	err = kickoff.SaveConfig(o.ConfigPath, &o.Config)
 	if err != nil {
 		return err
 	}
 
-	fmt.Fprintf(o.Out, "Created new skeleton repository in %s.\n\n", o.OutputDir)
+	fmt.Fprintf(o.Out, "Created new skeleton repository in %s.\n\n", o.RepoDir)
 	fmt.Fprintf(o.Out, "You can inspect it by running `kickoff skeleton list -r %s`.\n", o.RepoName)
 
 	return nil

--- a/internal/cmd/repository/remove.go
+++ b/internal/cmd/repository/remove.go
@@ -28,7 +28,7 @@ func NewRemoveCmd(streams cli.IOStreams) *cobra.Command {
 		Example: cmdutil.Examples(`
 			# Remove a skeleton repository
 			kickoff repository remove myrepo`),
-		Args: cobra.ExactArgs(1),
+		Args: cmdutil.ExactNonEmptyArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if err := o.Complete(args); err != nil {
 				return err
@@ -64,13 +64,9 @@ func (o *RemoveOptions) Complete(args []string) error {
 
 // Validate validates the remove options.
 func (o *RemoveOptions) Validate() error {
-	if o.RepoName == "" {
-		return ErrEmptyRepositoryName
-	}
-
 	_, ok := o.Repositories[o.RepoName]
 	if !ok {
-		return cmdutil.RepositoryNotConfiguredError{Name: o.RepoName}
+		return cmdutil.RepositoryNotConfiguredError(o.RepoName)
 	}
 
 	return nil

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -54,6 +54,13 @@ func NewRootCmd(streams cli.IOStreams) *cobra.Command {
 	}
 
 	cmd.PersistentFlags().StringVar(&logLevel, "log-level", logLevel, "Level for stderr log output")
+	cmd.RegisterFlagCompletionFunc("log-level", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		completions := make([]string, len(log.AllLevels))
+		for i, lvl := range log.AllLevels {
+			completions[i] = lvl.String()
+		}
+		return completions, cobra.ShellCompDirectiveDefault
+	})
 
 	cmd.AddCommand(NewCacheCmd(streams))
 	cmd.AddCommand(NewCompletionCmd(streams))

--- a/internal/cmd/skeleton/create.go
+++ b/internal/cmd/skeleton/create.go
@@ -1,7 +1,6 @@
 package skeleton
 
 import (
-	"errors"
 	"fmt"
 
 	"github.com/martinohmann/kickoff/internal/cli"
@@ -25,7 +24,7 @@ func NewCreateCmd(streams cli.IOStreams) *cobra.Command {
 		Example: cmdutil.Examples(`
 			# Create a new skeleton in myrepo
 			kickoff skeleton create myrepo myskeleton`),
-		Args: cobra.ExactArgs(2),
+		Args: cmdutil.ExactNonEmptyArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if err := o.Complete(args); err != nil {
 				return err
@@ -48,6 +47,7 @@ func NewCreateCmd(streams cli.IOStreams) *cobra.Command {
 type CreateOptions struct {
 	cli.IOStreams
 	cmdutil.ConfigFlags
+
 	RepoName     string
 	SkeletonName string
 }
@@ -62,19 +62,11 @@ func (o *CreateOptions) Complete(args []string) (err error) {
 
 // Validate validates the create options.
 func (o *CreateOptions) Validate() error {
-	if o.RepoName == "" {
-		return errors.New("repository name must not be empty")
-	}
-
-	if o.SkeletonName == "" {
-		return errors.New("skeleton name must not be empty")
-	}
-
 	if _, ok := o.Repositories[o.RepoName]; !ok {
-		return cmdutil.RepositoryNotConfiguredError{Name: o.RepoName}
+		return cmdutil.RepositoryNotConfiguredError(o.RepoName)
 	}
 
-	return o.ConfigFlags.Validate()
+	return nil
 }
 
 // Run creates a new project skeleton in the provided output directory.

--- a/internal/cmd/skeleton/create_test.go
+++ b/internal/cmd/skeleton/create_test.go
@@ -29,24 +29,6 @@ func TestCreateCmd(t *testing.T) {
 		Create()
 	defer os.Remove(configFile.Name())
 
-	t.Run("empty repo name", func(t *testing.T) {
-		cmd := newCreateCmd()
-		cmd.SetArgs([]string{"", "myskel", "--config", configFile.Name()})
-
-		err := cmd.Execute()
-		assert.EqualError(t, err, "repository name must not be empty")
-		assert.NoDirExists(t, myskelDir)
-	})
-
-	t.Run("empty skeleton name", func(t *testing.T) {
-		cmd := newCreateCmd()
-		cmd.SetArgs([]string{"myrepo", "", "--config", configFile.Name()})
-
-		err := cmd.Execute()
-		assert.EqualError(t, err, "skeleton name must not be empty")
-		assert.NoDirExists(t, myskelDir)
-	})
-
 	t.Run("repository does not exist", func(t *testing.T) {
 		cmd := newCreateCmd()
 		cmd.SetArgs([]string{"nonexistent", "default", "--config", configFile.Name()})

--- a/internal/cmd/skeleton/show.go
+++ b/internal/cmd/skeleton/show.go
@@ -34,7 +34,7 @@ func NewShowCmd(streams cli.IOStreams) *cobra.Command {
 
 			# Show skeleton config using different output
 			kickoff skeleton show myskeleton --output json`),
-		Args: cobra.ExactArgs(1),
+		Args: cmdutil.ExactNonEmptyArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if err := o.Complete(args); err != nil {
 				return err
@@ -62,12 +62,12 @@ type ShowOptions struct {
 	cmdutil.OutputFlag
 	cmdutil.TimeoutFlag
 
-	Skeleton string
+	SkeletonName string
 }
 
 // Complete completes the show options.
 func (o *ShowOptions) Complete(args []string) error {
-	o.Skeleton = args[0]
+	o.SkeletonName = args[0]
 
 	return o.ConfigFlags.Complete()
 }
@@ -83,7 +83,7 @@ func (o *ShowOptions) Run() error {
 		return err
 	}
 
-	skeleton, err := repository.LoadSkeleton(ctx, repo, o.Skeleton)
+	skeleton, err := repository.LoadSkeleton(ctx, repo, o.SkeletonName)
 	if err != nil {
 		return err
 	}

--- a/internal/cmd/skeleton/show_file.go
+++ b/internal/cmd/skeleton/show_file.go
@@ -29,13 +29,9 @@ func NewShowFileCmd(streams cli.IOStreams) *cobra.Command {
 		Example: cmdutil.Examples(`
 			# Show the content of a skeleton file in a specific repository
 			kickoff skeleton show-file myrepo:myskeleton relpath/to/file`),
-		Args: cobra.ExactArgs(2),
+		Args: cmdutil.ExactNonEmptyArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if err := o.Complete(args); err != nil {
-				return err
-			}
-
-			if err := o.Validate(); err != nil {
 				return err
 			}
 
@@ -55,13 +51,13 @@ type ShowFileOptions struct {
 	cmdutil.ConfigFlags
 	cmdutil.TimeoutFlag
 
-	Skeleton string
-	FilePath string
+	SkeletonName string
+	FilePath     string
 }
 
 // Complete completes the show options.
 func (o *ShowFileOptions) Complete(args []string) error {
-	o.Skeleton = args[0]
+	o.SkeletonName = args[0]
 	o.FilePath = filepath.Clean(args[1])
 
 	return o.ConfigFlags.Complete()
@@ -78,7 +74,7 @@ func (o *ShowFileOptions) Run() error {
 		return err
 	}
 
-	skeleton, err := repository.LoadSkeleton(ctx, repo, o.Skeleton)
+	skeleton, err := repository.LoadSkeleton(ctx, repo, o.SkeletonName)
 	if err != nil {
 		return err
 	}

--- a/internal/cmdutil/args.go
+++ b/internal/cmdutil/args.go
@@ -1,0 +1,25 @@
+package cmdutil
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+// ExactNonEmptyArgs returns an error if there are not exactly n args or if any
+// of them is an empty string.
+func ExactNonEmptyArgs(n int) cobra.PositionalArgs {
+	return func(cmd *cobra.Command, args []string) error {
+		if len(args) != n {
+			return fmt.Errorf("accepts %d non-empty arg(s), received %d", n, len(args))
+		}
+
+		for i, arg := range args {
+			if arg == "" {
+				return fmt.Errorf("accepts %d non-empty arg(s), received empty arg at position %d", n, i+1)
+			}
+		}
+
+		return nil
+	}
+}

--- a/internal/cmdutil/errors.go
+++ b/internal/cmdutil/errors.go
@@ -1,25 +1,17 @@
 package cmdutil
 
-import (
-	"errors"
-	"fmt"
-)
+import "fmt"
 
-var (
-	// ErrEmptyOutputDir is returned if the user passed an empty string as the
-	// output directory.
-	ErrEmptyOutputDir = errors.New("output dir must not be an empty string")
+type RepositoryAlreadyExistsError string
 
-	// ErrInvalidOutputFormat is returned if the output format flag contains an
-	// invalid value.
-	ErrInvalidOutputFormat = errors.New("--output must be 'yaml' or 'json'")
-)
-
-type RepositoryNotConfiguredError struct {
-	Name string
+// Error implements the error interface.
+func (e RepositoryAlreadyExistsError) Error() string {
+	return fmt.Sprintf("repository %q already exists", string(e))
 }
+
+type RepositoryNotConfiguredError string
 
 // Error implements the error interface.
 func (e RepositoryNotConfiguredError) Error() string {
-	return fmt.Sprintf("repository %q not configured", e.Name)
+	return fmt.Sprintf("repository %q not configured", string(e))
 }

--- a/internal/repository/create.go
+++ b/internal/repository/create.go
@@ -45,6 +45,10 @@ func Create(path string) (*kickoff.RepoRef, error) {
 // .kickoff.yaml and example README.md.skel as starter. Returns an error if
 // creating path or writing any of the files fails.
 func CreateSkeleton(ref *kickoff.RepoRef, name string) error {
+	if name == "" {
+		return errors.New("skeleton name must not be empty")
+	}
+
 	if ref.IsRemote() {
 		return errors.New("creating skeletons in remote repositories is not supported")
 	}


### PR DESCRIPTION
Changes:

- remove/simply obsolete validation
- remove version cmd `--short` flag. use `--output short` instead
- remove obsolete errors
- add completion for some flags
- remove obsolete cmd tests