### PR TITLE
feat!: improve ux of the project creation command

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -127,10 +127,13 @@ create our first project from a project skeleton.
 
 Let's say, we want to create a new project at `~/projects/myproject` using the
 `default` skeleton from the `default` repository. By running the following
-command it will setup the new project from our skeleton:
+command from within `~/projects` it will setup the new project from our
+skeleton:
 
 ```bash
-$ kickoff project create default:default ~/projects/myproject
+$ mkdir ~/projects
+$ cd ~/projects
+$ kickoff project create myproject default:default
 
 Creating project in ~/projects/myproject.
 
@@ -138,6 +141,8 @@ Creating project in ~/projects/myproject.
 
 Project creation complete. Created: 1, Overwritten: 0, Skipped: 0.
 ```
+
+**Note:** You can also pass a different directory via the `--dir` flag.
 
 What happened here? Kickoff created the new directory `~/projects/myproject`
 and copied all files and directories from the `default` skeleton into it,

--- a/docs/project-creation.md
+++ b/docs/project-creation.md
@@ -22,11 +22,14 @@ LICENSE file to your new project.
 The basic usage of the project creation command looks like this:
 
 ```bash
-$ kickoff project create [repo:]skeleton project-dir [flags...]
+$ kickoff project create <name> <skeleton-name> [<skeleton-name>...] [flags]
 ```
 
-It expects two arguments: the skeleton to create the project from and the
-directory where the project should be created.
+It expects at least two arguments: the project name and the name of at least
+one skeleton to create the project from. The new project is created in
+`$PWD/<name>`.
+
+**Note:** You can also pass a different directory via the `--dir` flag.
 
 The skeleton needs to be prefixed with the name of the repository if the
 skeleton name is ambiguous. For example:
@@ -68,8 +71,8 @@ Values          someKey: someValue
 Using the `--set` and `--values` flags you can override these:
 
 ```bash
-$ kickoff project create myskeleton ~/myproject --set someOtherKey.someNestedKey=43
-$ kickoff project create myskeleton ~/myproject --value values.yaml 
+$ kickoff project create myproject myskeleton --set someOtherKey.someNestedKey=43
+$ kickoff project create myproject myskeleton --value values.yaml 
 ```
 
 Refer to the [Accessing and setting template
@@ -87,7 +90,7 @@ API](https://developer.github.com/v3/licenses/).
 To add a license to your project, just specify its name using the `--license` flag:
 
 ```bash
-$ kickoff project create myskeleton ~/myproject --license MIT
+$ kickoff project create myproject myskeleton --license MIT
 ```
 
 It will automatically fill in the year and project owner into the license if
@@ -122,7 +125,7 @@ be built from one or multiple gitignore templates from
 separated list via the `--gitignore` flag:
 
 ```bash
-$ kickoff project create myskeleton ~/myproject --gitignore go,hugo
+$ kickoff project create myproject myskeleton --gitignore go,hugo
 ```
 
 For a list of available `.gitignore` templates run:
@@ -141,17 +144,17 @@ Use the `--dry-run` flag if you just want to see which files and directories
 would be created for your new project:
 
 ```bash
-$ kickoff project create myskeleton ~/myproject --dry-run
+$ kickoff project create myproject myskeleton --dry-run
 ```
 
 ## Creating a project from multiple skeletons
 
 Projects can be created by composing multiple skeletons together. This is just
-as simple as providing multiple skeletons instead of one as comma separated
-list on project creation:
+as simple as providing multiple skeletons instead of one after the project name
+on project creation:
 
 ```bash
-$ kickoff project create skeleton1,skeleton2,skeleton3 ~/myproject
+$ kickoff project create myproject repo:skeleton1 otherrepo:skeleton2 skeleton3
 ```
 
 Note that the skeletons are merged left to right, so files and values from

--- a/docs/repositories.md
+++ b/docs/repositories.md
@@ -52,7 +52,7 @@ Add a remote skeleton repository and create a new project:
 ```bash
 $ kickoff repository add myremoterepo https://github.com/myuser/myskeletonrepo?revision=v1.0.0
 $ kickoff repository list
-$ kickoff project create myremoterepo:myskeleton ~/path/to/my/new/project
+$ kickoff project create myproject myremoterepo:myskeleton
 ```
 
 Remote repository urls can contain an optional `revision` query parameter which

--- a/docs/skeletons/composition.md
+++ b/docs/skeletons/composition.md
@@ -14,11 +14,11 @@ nav_order: 6
 {:toc}
 
 Projects can be created by composing multiple skeletons together. This is just
-as simple as providing multiple skeletons instead of one as comma separated
-list on project creation:
+as simple as providing multiple skeletons instead of one after the project name
+on project creation:
 
 ```bash
-kickoff project create skeleton1,skeleton2,skeleton3 /path/to/project
+$ kickoff project create myproject repo:skeleton1 otherrepo:skeleton2 skeleton3
 ```
 
 Note that the skeletons are merged left to right, so files and values from

--- a/docs/skeletons/templating.md
+++ b/docs/skeletons/templating.md
@@ -104,10 +104,10 @@ values:
   myVar: myValue
 
 # on project creation via --set:
-$ kickoff project create default ~/myproj --set myVar=myValue
+$ kickoff project create myproject default --set myVar=myValue
 
 # on project creation via --values:
-$ kickoff project create default ~/myproj --values values.yaml
+$ kickoff project create myproject default --values values.yaml
 
 # where values.yaml contains myVar:
 ---


### PR DESCRIPTION
This changes the project creation command from:

```
kickoff project create <skeleton-name> <dir>
```

to

```
kickoff project create <project-name> <skeleton-name> [<skeleton-name>...]
```

This is a breaking change but helps with autocompletion of skeleton
names. Furthermore it now accepts a project name instead of a directory
as argument. The project will be created in `$PWD/<project-name>` by
default but this can be overridden via the `--dir` flag. As a
consequence the `--name` flag was removed.