### PR TITLE
feat: print skeleton names next to files on project creation

### DIFF
--- a/internal/kickoff/file.go
+++ b/internal/kickoff/file.go
@@ -16,6 +16,10 @@ type BufferedFile struct {
 	// Mode is the os.Mode for the file. This provides information about the
 	// type of file, e.g. whether it is a directory or not.
 	Mode os.FileMode `json:"mode"`
+	// SkeletonRef contains the ref to the skeleton the file originated from or
+	// nil if it does not belong to a specific skeleton. Used to keep track of
+	// file origins during skeleton composition.
+	SkeletonRef *SkeletonRef `json:"-"`
 }
 
 // MergeFiles merges two lists of files. Files in the rhs list take precedence

--- a/internal/project/result.go
+++ b/internal/project/result.go
@@ -75,29 +75,26 @@ func (p *Project) writeSummary(w io.Writer) {
 
 		switch action.Type {
 		case ActionTypeSkipUser:
-			status = color.YellowString("! skip ") + color.HiBlackString("(user)")
+			status = color.YellowString("! skipped ") + color.HiBlackString("(user)")
 		case ActionTypeSkipExisting:
-			status = color.YellowString("! skip ") + color.HiBlackString("(exists)")
+			status = color.YellowString("! skipped ") + color.HiBlackString("(exists)")
 		case ActionTypeOverwrite:
-			status = color.RedString("✓ overwrite")
+			status = color.RedString("✓ overwritten")
 		default:
-			status = color.GreenString("✓ create")
+			status = color.GreenString("✓ created")
 		}
 
-		var destPath string
-
-		if source.RelPath != dest.RelPath() {
-			destPath = fmt.Sprintf(
-				"%s %s",
-				color.HiBlackString("=❯"),
-				colorizePath(dest.RelPath()+dirSuffix),
-			)
+		origin := "<generated>"
+		if ref := source.SkeletonRef; ref != nil {
+			origin = ref.String()
 		}
 
 		tw.Append(
 			color.HiBlackString("❯"),
+			color.BlueString(origin),
 			colorizePath(source.RelPath+dirSuffix),
-			destPath,
+			color.HiBlackString("=❯"),
+			colorizePath(dest.RelPath()+dirSuffix),
 			status,
 		)
 	}

--- a/internal/repository/repo.go
+++ b/internal/repository/repo.go
@@ -237,8 +237,9 @@ func loadSkeletonFiles(ref *kickoff.SkeletonRef) ([]*kickoff.BufferedFile, error
 
 		if fi.Mode().IsDir() {
 			files = append(files, &kickoff.BufferedFile{
-				RelPath: relPath,
-				Mode:    fi.Mode(),
+				RelPath:     relPath,
+				Mode:        fi.Mode(),
+				SkeletonRef: ref,
 			})
 			return nil
 		}
@@ -257,9 +258,10 @@ func loadSkeletonFiles(ref *kickoff.SkeletonRef) ([]*kickoff.BufferedFile, error
 		}
 
 		files = append(files, &kickoff.BufferedFile{
-			RelPath: relPath,
-			Content: buf,
-			Mode:    fi.Mode(),
+			RelPath:     relPath,
+			Content:     buf,
+			Mode:        fi.Mode(),
+			SkeletonRef: ref,
 		})
 		return nil
 	})


### PR DESCRIPTION
This makes it more visible to the user where certain files are coming
from. Especially useful when using multiple skeletons at once
(composition) or when letting kickoff generate license/gitignore.

Other output fixes:

- use past tense in output (e.g. `created` instead of `create`).
- always display destination path as it makes the output more consistent
  and easier to parse for the human eye.