### PR TITLE
feat: move to GitHub Gitignores API

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,9 +26,9 @@ into the [Getting started guide](https://kickoff.run/getting-started).
 - Extensible by allowing users to pass arbitrary values to templates via config
   files or CLI flags.
 - Automatically populate LICENSE file with an open source license obtained from
-  the [GitHub Licenses API](https://developer.github.com/v3/licenses/).
+  the [GitHub Licenses API](https://docs.github.com/en/rest/reference/licenses).
 - Automatically add a .gitignore created from templates obtained from
-  [gitignore.io](https://gitignore.io).
+  [GitHub Gitignores API](https://docs.github.com/en/rest/reference/gitignore).
 - Set local author, repository and skeleton defaults using custom config file.
 - Dry run for project creation.
 - Skeleton composition: projects can be created by composing multiple skeletons

--- a/docs/index.md
+++ b/docs/index.md
@@ -26,9 +26,9 @@ existing projects to a new one.
 - Extensible by allowing users to pass arbitrary values to templates via config
   files or CLI flags.
 - Automatically populate LICENSE file with an open source license obtained from
-  the [GitHub Licenses API](https://developer.github.com/v3/licenses/).
+  the [GitHub Licenses API](https://docs.github.com/en/rest/reference/licenses).
 - Automatically add a .gitignore created from templates obtained from
-  [gitignore.io](https://gitignore.io).
+  [GitHub Gitignores API](https://docs.github.com/en/rest/reference/gitignore).
 - Set local author, repository and skeleton defaults using custom config file.
 - Dry run for project creation.
 - Skeleton composition: projects can be created by composing multiple skeletons

--- a/docs/project-creation.md
+++ b/docs/project-creation.md
@@ -85,7 +85,7 @@ documentation for more information.
 
 Kickoff can automatically add a `LICENSE` file containing a popular open source
 license which is obtained via the [GitHub Licenses
-API](https://developer.github.com/v3/licenses/).
+API](https://docs.github.com/en/rest/reference/licenses).
 
 To add a license to your project, just specify its name using the `--license` flag:
 
@@ -120,9 +120,9 @@ used for all new projects if not explicitly overridden.
 ## Including a `.gitignore`
 
 You can automatically include a `.gitignore` file with your project which can
-be built from one or multiple gitignore templates from
-[gitignore.io](https://gitignore.io/). The templates can be passed as comma
-separated list via the `--gitignore` flag:
+be built from one or multiple gitignore templates available via the [GitHub
+Gitignores API](https://docs.github.com/en/rest/reference/gitignore). The
+templates can be passed as comma separated list via the `--gitignore` flag:
 
 ```bash
 $ kickoff project create myproject myskeleton --gitignore go,hugo

--- a/internal/cmd/gitignore.go
+++ b/internal/cmd/gitignore.go
@@ -7,7 +7,7 @@ import (
 )
 
 // NewGitignoreCmd creates a new command which provides subcommands for
-// inspecting gitignore templates provided by gitignore.io.
+// inspecting gitignore templates available via the GitHub Gitignores API.
 func NewGitignoreCmd(f *cmdutil.Factory) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "gitignore",

--- a/internal/cmd/gitignore/list.go
+++ b/internal/cmd/gitignore/list.go
@@ -10,8 +10,8 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// NewListCmd creates a command that lists all gitignore templates available on
-// gitignore.io.
+// NewListCmd creates a command that lists all gitignore templates available
+// via the GitHub Gitignores API.
 func NewListCmd(f *cmdutil.Factory) *cobra.Command {
 	var output string
 
@@ -20,9 +20,7 @@ func NewListCmd(f *cmdutil.Factory) *cobra.Command {
 		Aliases: []string{"ls"},
 		Short:   "List available gitignores",
 		Long: cmdutil.LongDesc(`
-			Lists gitignores available via the gitignore.io API.
-
-			Check out https://www.gitignore.io for more information about .gitignore templates.`),
+			Lists all gitignore templates available via the GitHub Gitignores API (https://docs.github.com/en/rest/reference/gitignore#get-all-gitignore-templates).`),
 		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			client := gitignore.NewClient(f.HTTPClient())

--- a/internal/cmd/gitignore/show.go
+++ b/internal/cmd/gitignore/show.go
@@ -2,7 +2,6 @@ package gitignore
 
 import (
 	"context"
-	"fmt"
 	"strings"
 
 	"github.com/martinohmann/kickoff/internal/cmdutil"
@@ -17,9 +16,7 @@ func NewShowCmd(f *cmdutil.Factory) *cobra.Command {
 		Use:   "show <name> [<name>...]",
 		Short: "Fetch a gitignore template",
 		Long: cmdutil.LongDesc(`
-			Fetches a gitignore template via the gitignore.io API.
-
-			Check out https://www.gitignore.io for more information about .gitignore templates.`),
+			Fetches a gitignore template via the GitHub Gitignores API (https://docs.github.com/en/rest/reference/gitignore#get-a-gitignore-template).`),
 		Example: cmdutil.Examples(`
 			# Fetch a single template
 			kickoff gitignore show go
@@ -40,9 +37,8 @@ func NewShowCmd(f *cmdutil.Factory) *cobra.Command {
 				return err
 			}
 
-			fmt.Fprintln(f.IOStreams.Out, string(template.Content))
-
-			return nil
+			_, err = f.IOStreams.Out.Write(template.Content)
+			return err
 		},
 	}
 

--- a/internal/cmd/license/list.go
+++ b/internal/cmd/license/list.go
@@ -20,7 +20,7 @@ func NewListCmd(f *cmdutil.Factory) *cobra.Command {
 		Aliases: []string{"ls"},
 		Short:   "List available licenses",
 		Long: cmdutil.LongDesc(`
-			Lists licenses available via the GitHub Licenses API (https://developer.github.com/v3/licenses/#list-all-licenses).`),
+			Lists licenses available via the GitHub Licenses API (https://docs.github.com/en/rest/reference/licenses#get-all-commonly-used-licenses).`),
 		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			client := license.NewClient(f.HTTPClient())

--- a/internal/cmd/license/show.go
+++ b/internal/cmd/license/show.go
@@ -16,7 +16,7 @@ func NewShowCmd(f *cmdutil.Factory) *cobra.Command {
 		Use:   "show <key>",
 		Short: "Fetch a license text",
 		Long: cmdutil.LongDesc(`
-			Fetches a license text via the GitHub Licenses API (https://developer.github.com/v3/licenses/#get-an-individual-license).`),
+			Fetches a license text via the GitHub Licenses API (https://docs.github.com/en/rest/reference/licenses#get-a-license).`),
 		Example: cmdutil.Examples(`
 			# Show MIT license text
 			kickoff license show mit`),

--- a/internal/cmdutil/completion_test.go
+++ b/internal/cmdutil/completion_test.go
@@ -24,8 +24,8 @@ func TestCompletion(t *testing.T) {
 	httpmock.Activate()
 	defer httpmock.DeactivateAndReset()
 
-	httpmock.RegisterResponder("GET", "https://www.toptal.com/developers/gitignore/api/list",
-		httpmock.NewStringResponder(200, "hugo\ngo"))
+	httpmock.RegisterResponder("GET", "https://api.github.com/gitignore/templates",
+		httpmock.NewStringResponder(200, `["go", "hugo"]`))
 
 	assert.Equal(t, []string{"go", "hugo"}, GitignoreNames(f))
 


### PR DESCRIPTION
Replaces usage of the https://www.toptal.com/developers/gitignore API
with the GitHub Gitignores API.

While this change required a little more code to get to the same
behaviour as the old API showed, it has some advantages:

- Reduces kickoff's third-party API dependencies to one.
- Gitignore templates can finally be cached properly. The toptal API
  marked requests as uncacheable in their responses. This was very
  unfortunate as there was a noticeable delay in any kickoff operation
  involving gitignores. GitHub set proper cache headers which should
  speed things up considerably.

The change will decrease the number of available gitignore templates
from 522 to 127 but I think that less is more and since gitignore
templates can be composed (e.g. "go,python,...") this should be enough.