### PR TITLE
feat: add tests for project create command

### DIFF
--- a/internal/cmd/project/create.go
+++ b/internal/cmd/project/create.go
@@ -19,6 +19,7 @@ import (
 	"github.com/martinohmann/kickoff/internal/kickoff"
 	"github.com/martinohmann/kickoff/internal/license"
 	"github.com/martinohmann/kickoff/internal/project"
+	"github.com/martinohmann/kickoff/internal/prompt"
 	"github.com/martinohmann/kickoff/internal/repository"
 	"github.com/martinohmann/kickoff/internal/template"
 	log "github.com/sirupsen/logrus"
@@ -35,6 +36,7 @@ func NewCreateCmd(f *cmdutil.Factory) *cobra.Command {
 		GitClient:  f.GitClient,
 		HTTPClient: f.HTTPClient,
 		Repository: f.Repository,
+		Prompt:     f.Prompt,
 	}
 
 	cmd := &cobra.Command{
@@ -109,6 +111,7 @@ type CreateOptions struct {
 	GitClient  func() git.Client
 	HTTPClient func() *http.Client
 	Repository func(...string) (kickoff.Repository, error)
+	Prompt     prompt.Prompt
 
 	ProjectName  string
 	ProjectDir   string
@@ -341,12 +344,12 @@ func (o *CreateOptions) createProject(ctx context.Context, skeleton *kickoff.Ske
 
 func (o *CreateOptions) confirmApply() (apply bool, err error) {
 	if _, err = os.Stat(o.ProjectDir); err == nil {
-		err = survey.AskOne(&survey.Confirm{
+		err = o.Prompt.AskOne(&survey.Confirm{
 			Message: fmt.Sprintf("Project directory %s already exists, still create project?", homedir.Collapse(o.ProjectDir)),
 			Default: false,
 		}, &apply)
 	} else {
-		err = survey.AskOne(&survey.Confirm{
+		err = o.Prompt.AskOne(&survey.Confirm{
 			Message: fmt.Sprintf("Create project in %s?", homedir.Collapse(o.ProjectDir)),
 			Default: true,
 		}, &apply)

--- a/internal/cmd/project/create_test.go
+++ b/internal/cmd/project/create_test.go
@@ -1,0 +1,210 @@
+package project
+
+import (
+	"io/ioutil"
+	"net/http"
+	"path/filepath"
+	"testing"
+
+	"github.com/jarcoal/httpmock"
+	"github.com/martinohmann/kickoff/internal/cli"
+	"github.com/martinohmann/kickoff/internal/cmdutil"
+	"github.com/martinohmann/kickoff/internal/prompt"
+	"github.com/martinohmann/kickoff/internal/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCreate(t *testing.T) {
+	configPath := testutil.NewConfigFileBuilder(t).
+		WithRepository("default", "../../testdata/repos/repo1").
+		WithRepository("other", "../../testdata/repos/repo2").
+		Create()
+
+	streams, _, _, _ := cli.NewTestIOStreams()
+
+	f := cmdutil.NewFactoryWithConfigPath(streams, configPath)
+	f.HTTPClient = func() *http.Client { return http.DefaultClient }
+
+	httpmock.Activate()
+	defer httpmock.DeactivateAndReset()
+
+	httpmock.RegisterResponder("GET", "https://api.github.com/gitignore/templates",
+		httpmock.NewStringResponder(200, `["go", "hugo"]`))
+	httpmock.RegisterResponder("GET", "https://api.github.com/gitignore/templates/go",
+		httpmock.NewStringResponder(200, `{"name":"go","source":"the-gitignore-template"}`))
+	httpmock.RegisterResponder("GET", "https://api.github.com/licenses",
+		httpmock.NewStringResponder(200, `[{"key":"mit","name":"MIT License"},{"key":"unlicense","name":"The Unlicense"}]`))
+	httpmock.RegisterResponder("GET", "https://api.github.com/licenses/mit",
+		httpmock.NewStringResponder(200, `{"key":"mit","name":"MIT License","body":"the-mit-license"}`))
+	httpmock.RegisterResponder("GET", "https://api.github.com/licenses/unlicense",
+		httpmock.NewStringResponder(200, `{"key":"unlicense","name":"The Unlicense","body":"the-unlicense"}`))
+
+	t.Run("empty skeleton does not create project dir", func(t *testing.T) {
+		dir := filepath.Join(t.TempDir(), "myproject")
+
+		stubPrompt(f)
+
+		cmd := NewCreateCmd(f)
+		cmd.SetArgs([]string{"myproject", "default:minimal", "-d", dir, "--owner", "johndoe"})
+		cmd.SetOut(ioutil.Discard)
+
+		require.NoError(t, cmd.Execute())
+		require.NoDirExists(t, dir)
+	})
+
+	t.Run("creates project from skeleton", func(t *testing.T) {
+		dir := filepath.Join(t.TempDir(), "myproject")
+
+		stubber, fakePrompt := stubPrompt(f)
+
+		cmd := NewCreateCmd(f)
+		cmd.SetArgs([]string{"myproject", "default:advanced", "-d", dir, "--owner", "johndoe"})
+		cmd.SetOut(ioutil.Discard)
+
+		// confirm apply
+		stubber.StubOne(true)
+
+		require.NoError(t, cmd.Execute())
+
+		fakePrompt.AssertExpectations(t)
+
+		require.DirExists(t, dir)
+	})
+
+	t.Run("creates project interactively", func(t *testing.T) {
+		dir := filepath.Join(t.TempDir(), "myproject")
+
+		stubber, fakePrompt := stubPrompt(f)
+
+		cmd := NewCreateCmd(f)
+		cmd.SetOut(ioutil.Discard)
+
+		// skeleton names
+		stubber.StubOne([]string{"default:advanced"})
+
+		// project config
+		stubber.StubMany("myotherproject", dir)
+		stubber.StubOneDefault()
+		stubber.StubOne("johndoe")
+
+		// license
+		stubber.StubOne("MIT License")
+
+		// gitignores
+		stubber.StubOne([]string{"go"})
+
+		// init git?
+		stubber.StubOne(true)
+
+		// edit values?
+		stubber.StubOne(true)
+
+		// config edit result
+		stubber.StubOne("{}")
+
+		// confirm apply
+		stubber.StubOne(true)
+
+		require.NoError(t, cmd.Execute())
+
+		fakePrompt.AssertExpectations(t)
+
+		require.DirExists(t, dir)
+		require.DirExists(t, filepath.Join(dir, ".git"))
+		require.FileExists(t, filepath.Join(dir, "LICENSE"))
+		require.FileExists(t, filepath.Join(dir, ".gitignore"))
+		require.FileExists(t, filepath.Join(dir, "foobar", "somefile.yaml"))
+	})
+
+	t.Run("overwrite files in --overwrite flag is provided", func(t *testing.T) {
+		dir := filepath.Join(t.TempDir(), "myproject")
+
+		stubber, fakePrompt := stubPrompt(f)
+
+		// create a project
+		cmd := NewCreateCmd(f)
+		cmd.SetArgs([]string{
+			"myproject", "default:advanced", "-d", dir,
+			"--owner", "johndoe", "--license", "mit",
+		})
+		cmd.SetOut(ioutil.Discard)
+
+		// confirm apply
+		stubber.StubOne(true)
+
+		require.NoError(t, cmd.Execute())
+		assertFileContains(t, filepath.Join(dir, "LICENSE"), "the-mit-license")
+
+		// create a project in the same dir again but with different license, without passing overwrite
+		cmd = NewCreateCmd(f)
+		cmd.SetArgs([]string{
+			"myproject", "default:advanced", "-d", dir,
+			"--owner", "johndoe", "--license", "unlicense",
+		})
+		cmd.SetOut(ioutil.Discard)
+
+		require.NoError(t, cmd.Execute())
+		assertFileContains(t, filepath.Join(dir, "LICENSE"), "the-mit-license")
+
+		// create a project in the same dir again, this time overwrite all existing files
+		cmd = NewCreateCmd(f)
+		cmd.SetArgs([]string{
+			"myproject", "default:advanced", "-d", dir,
+			"--owner", "johndoe", "--license", "unlicense", "--overwrite",
+		})
+		cmd.SetOut(ioutil.Discard)
+
+		// confirm apply
+		stubber.StubOne(true)
+
+		require.NoError(t, cmd.Execute())
+		assertFileContains(t, filepath.Join(dir, "LICENSE"), "the-unlicense")
+
+		fakePrompt.AssertExpectations(t)
+	})
+
+	t.Run("interactive mode only prompts for things not explicitly set", func(t *testing.T) {
+		dir := filepath.Join(t.TempDir(), "myproject")
+
+		stubber, fakePrompt := stubPrompt(f)
+
+		cmd := NewCreateCmd(f)
+		cmd.SetArgs([]string{
+			"myproject", "default:advanced", "-d", dir,
+			"--license", "unlicense", "--gitignore", "go",
+			"--set", "filename=barbaz", "--init-git",
+			"--interactive",
+		})
+		cmd.SetOut(ioutil.Discard)
+
+		// project config
+		stubber.StubOneDefault()
+		stubber.StubOne("johndoe")
+
+		// confirm apply
+		stubber.StubOne(true)
+
+		require.NoError(t, cmd.Execute())
+
+		fakePrompt.AssertExpectations(t)
+
+		require.DirExists(t, dir)
+		require.DirExists(t, filepath.Join(dir, ".git"))
+		require.FileExists(t, filepath.Join(dir, "LICENSE"))
+		require.FileExists(t, filepath.Join(dir, ".gitignore"))
+		require.FileExists(t, filepath.Join(dir, "barbaz", "somefile.yaml"))
+	})
+}
+
+func stubPrompt(f *cmdutil.Factory) (*prompt.Stubber, *prompt.FakePrompt) {
+	stubber, fakePrompt := prompt.NewStubber()
+	f.Prompt = fakePrompt
+	return stubber, fakePrompt
+}
+
+func assertFileContains(t *testing.T, path, expectedContent string) {
+	contents, err := ioutil.ReadFile(path)
+	require.NoError(t, err)
+	assert.Equal(t, expectedContent, string(contents))
+}

--- a/internal/cmdutil/factory.go
+++ b/internal/cmdutil/factory.go
@@ -10,6 +10,7 @@ import (
 	"github.com/martinohmann/kickoff/internal/git"
 	"github.com/martinohmann/kickoff/internal/httpcache"
 	"github.com/martinohmann/kickoff/internal/kickoff"
+	"github.com/martinohmann/kickoff/internal/prompt"
 	"github.com/martinohmann/kickoff/internal/repository"
 )
 
@@ -22,6 +23,7 @@ type Factory struct {
 	GitClient  func() git.Client
 	HTTPClient func() *http.Client
 	Repository func(...string) (kickoff.Repository, error)
+	Prompt     prompt.Prompt
 }
 
 // NewFactory creates the default *Factory that is passed to commands.
@@ -85,6 +87,7 @@ func NewFactoryWithConfigPath(ioStreams cli.IOStreams, configPath string) *Facto
 		GitClient:  git.NewClient,
 		HTTPClient: httpcache.NewClient,
 		Repository: repositoryFunc,
+		Prompt:     prompt.New(),
 	}
 }
 

--- a/internal/prompt/prompt.go
+++ b/internal/prompt/prompt.go
@@ -1,0 +1,83 @@
+package prompt
+
+import (
+	"reflect"
+
+	"github.com/AlecAivazis/survey/v2"
+	"github.com/AlecAivazis/survey/v2/core"
+	"github.com/stretchr/testify/mock"
+)
+
+// Prompt can be used to request user input.
+type Prompt interface {
+	AskOne(p survey.Prompt, response interface{}, opts ...survey.AskOpt) error
+}
+
+type prompt struct{}
+
+// New returns a prompt which just directly calls survey.AskOne.
+func New() Prompt { return new(prompt) }
+
+// AskOne implements Prompt.
+func (prompt) AskOne(p survey.Prompt, response interface{}, opts ...survey.AskOpt) error {
+	return survey.AskOne(p, response, opts...)
+}
+
+// FakePrompt is a mock implementation of a Prompt.
+type FakePrompt struct {
+	mock.Mock
+}
+
+// AskOne implements Prompt.
+func (f *FakePrompt) AskOne(p survey.Prompt, response interface{}, opts ...survey.AskOpt) error {
+	args := f.Called(p, response, opts)
+	return args.Error(0)
+}
+
+// Stubber can stub prompts.
+type Stubber struct {
+	p *FakePrompt
+}
+
+// NewStubber creates a new *Stubber which can stub out calls to returned
+// *FakePrompt's AskOne method.
+func NewStubber() (*Stubber, *FakePrompt) {
+	s := &Stubber{p: &FakePrompt{}}
+	return s, s.p
+}
+
+// StubOne makes the next prompt return value.
+func (s *Stubber) StubOne(value interface{}) {
+	s.p.On("AskOne", mock.Anything, mock.Anything, mock.Anything).
+		Run(func(args mock.Arguments) {
+			_ = core.WriteAnswer(args.Get(1), "", value)
+		}).
+		Return(nil).
+		Once()
+}
+
+// StubOneDefault makes the next prompt return its default value.
+func (s *Stubber) StubOneDefault() {
+	s.p.On("AskOne", mock.Anything, mock.Anything, mock.Anything).
+		Run(func(args mock.Arguments) {
+			fieldValue := reflect.ValueOf(args.Get(0)).Elem().FieldByName("Default")
+			defaultValue := fieldValue.Interface()
+			_ = core.WriteAnswer(args.Get(1), "", defaultValue)
+		}).
+		Return(nil).
+		Once()
+}
+
+// StubOneError makes the next prompt return err.
+func (s *Stubber) StubOneError(err error) {
+	s.p.On("AskOne", mock.Anything, mock.Anything, mock.Anything).
+		Return(err).
+		Once()
+}
+
+// StubOne makes the next prompts return the provided values.
+func (s *Stubber) StubMany(values ...interface{}) {
+	for _, value := range values {
+		s.StubOne(value)
+	}
+}


### PR DESCRIPTION
Changes:

- add `prompt` package which contains a production and testing implementation of the user prompt
- add tests for the `project create` command