### PR TITLE
chore: drop go1.15 support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ jobs:
   build:
     strategy:
       matrix:
-        go-version: [1.15.x, 1.16.x]
+        go-version: [1.16.x]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/martinohmann/kickoff
 
-go 1.15
+go 1.16
 
 require (
 	github.com/AlecAivazis/survey/v2 v2.2.12

--- a/internal/cmd/config/edit.go
+++ b/internal/cmd/config/edit.go
@@ -2,7 +2,6 @@ package config
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"strings"
@@ -72,7 +71,7 @@ func (o *EditOptions) Run() (err error) {
 		return err
 	}
 
-	tmpf, err := ioutil.TempFile("", "kickoff-*.yaml")
+	tmpf, err := os.CreateTemp("", "kickoff-*.yaml")
 	if err != nil {
 		return fmt.Errorf("failed to create temporary file: %w", err)
 	}
@@ -86,13 +85,11 @@ func (o *EditOptions) Run() (err error) {
 		"configfile": o.ConfigPath,
 	}).Debug("writing config to temporary file")
 
-	err = ioutil.WriteFile(tmpfilePath, contents, 0644)
-	if err != nil {
+	if err := os.WriteFile(tmpfilePath, contents, 0644); err != nil {
 		return err
 	}
 
-	err = launchEditor(tmpfilePath)
-	if err != nil {
+	if err := launchEditor(tmpfilePath); err != nil {
 		return err
 	}
 

--- a/internal/cmd/config/edit_test.go
+++ b/internal/cmd/config/edit_test.go
@@ -1,7 +1,8 @@
 package config
 
 import (
-	"io/ioutil"
+	"io"
+	"os"
 	"testing"
 
 	"github.com/martinohmann/kickoff/internal/cli"
@@ -70,7 +71,7 @@ func TestEditCmd(t *testing.T) {
 			WithValues(template.Values{"foo": "bar"}).
 			Create()
 
-		configBuf, err := ioutil.ReadFile(configPath)
+		configBuf, err := os.ReadFile(configPath)
 		require.NoError(t, err)
 
 		streams, _, _, _ := cli.NewTestIOStreams()
@@ -78,7 +79,7 @@ func TestEditCmd(t *testing.T) {
 		f := cmdutil.NewFactoryWithConfigPath(streams, configPath)
 
 		cmd := NewEditCmd(f)
-		cmd.SetOut(ioutil.Discard)
+		cmd.SetOut(io.Discard)
 
 		expectedErrPattern := `error while launching editor command "sh -c ./nonexistent /tmp/kickoff-[0-9]+.yaml": exit status 127`
 
@@ -87,7 +88,7 @@ func TestEditCmd(t *testing.T) {
 
 		assert.Regexp(t, expectedErrPattern, err)
 
-		configBuf2, err := ioutil.ReadFile(configPath)
+		configBuf2, err := os.ReadFile(configPath)
 		require.NoError(t, err)
 
 		assert.Equal(t, configBuf, configBuf2, "config file was changed although it should not")

--- a/internal/cmd/config/show_test.go
+++ b/internal/cmd/config/show_test.go
@@ -1,7 +1,7 @@
 package config
 
 import (
-	"io/ioutil"
+	"io"
 	"path/filepath"
 	"testing"
 
@@ -23,7 +23,7 @@ func TestShowCmd(t *testing.T) {
 		f := cmdutil.NewFactoryWithConfigPath(streams, configPath)
 
 		cmd := NewShowCmd(f)
-		cmd.SetOut(ioutil.Discard)
+		cmd.SetOut(io.Discard)
 
 		require.NoError(t, cmd.Execute())
 
@@ -40,7 +40,7 @@ func TestShowCmd(t *testing.T) {
 		f := cmdutil.NewFactoryWithConfigPath(streams, nonexistent)
 
 		cmd := NewShowCmd(f)
-		cmd.SetOut(ioutil.Discard)
+		cmd.SetOut(io.Discard)
 
 		require.Error(t, cmd.Execute())
 	})

--- a/internal/cmd/project/create_test.go
+++ b/internal/cmd/project/create_test.go
@@ -1,8 +1,9 @@
 package project
 
 import (
-	"io/ioutil"
+	"io"
 	"net/http"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -47,7 +48,7 @@ func TestCreate(t *testing.T) {
 
 		cmd := NewCreateCmd(f)
 		cmd.SetArgs([]string{"myproject", "default:minimal", "-d", dir, "--owner", "johndoe"})
-		cmd.SetOut(ioutil.Discard)
+		cmd.SetOut(io.Discard)
 
 		require.NoError(t, cmd.Execute())
 		require.NoDirExists(t, dir)
@@ -60,7 +61,7 @@ func TestCreate(t *testing.T) {
 
 		cmd := NewCreateCmd(f)
 		cmd.SetArgs([]string{"myproject", "default:advanced", "-d", dir, "--owner", "johndoe"})
-		cmd.SetOut(ioutil.Discard)
+		cmd.SetOut(io.Discard)
 
 		// confirm apply
 		stubber.StubOne(true)
@@ -78,7 +79,7 @@ func TestCreate(t *testing.T) {
 		stubber, fakePrompt := stubPrompt(f)
 
 		cmd := NewCreateCmd(f)
-		cmd.SetOut(ioutil.Discard)
+		cmd.SetOut(io.Discard)
 
 		// skeleton names
 		stubber.StubOne([]string{"default:advanced"})
@@ -128,7 +129,7 @@ func TestCreate(t *testing.T) {
 			"myproject", "default:advanced", "-d", dir,
 			"--owner", "johndoe", "--license", "mit",
 		})
-		cmd.SetOut(ioutil.Discard)
+		cmd.SetOut(io.Discard)
 
 		// confirm apply
 		stubber.StubOne(true)
@@ -142,7 +143,7 @@ func TestCreate(t *testing.T) {
 			"myproject", "default:advanced", "-d", dir,
 			"--owner", "johndoe", "--license", "unlicense",
 		})
-		cmd.SetOut(ioutil.Discard)
+		cmd.SetOut(io.Discard)
 
 		require.NoError(t, cmd.Execute())
 		assertFileContains(t, filepath.Join(dir, "LICENSE"), "the-mit-license")
@@ -153,7 +154,7 @@ func TestCreate(t *testing.T) {
 			"myproject", "default:advanced", "-d", dir,
 			"--owner", "johndoe", "--license", "unlicense", "--overwrite",
 		})
-		cmd.SetOut(ioutil.Discard)
+		cmd.SetOut(io.Discard)
 
 		// confirm apply
 		stubber.StubOne(true)
@@ -176,7 +177,7 @@ func TestCreate(t *testing.T) {
 			"--set", "filename=barbaz", "--init-git",
 			"--interactive",
 		})
-		cmd.SetOut(ioutil.Discard)
+		cmd.SetOut(io.Discard)
 
 		// project config
 		stubber.StubOneDefault()
@@ -204,7 +205,7 @@ func stubPrompt(f *cmdutil.Factory) (*prompt.Stubber, *prompt.FakePrompt) {
 }
 
 func assertFileContains(t *testing.T, path, expectedContent string) {
-	contents, err := ioutil.ReadFile(path)
+	contents, err := os.ReadFile(path)
 	require.NoError(t, err)
 	assert.Equal(t, expectedContent, string(contents))
 }

--- a/internal/cmd/repository/add_test.go
+++ b/internal/cmd/repository/add_test.go
@@ -1,7 +1,7 @@
 package repository
 
 import (
-	"io/ioutil"
+	"io"
 	"testing"
 
 	"github.com/martinohmann/kickoff/internal/cli"
@@ -24,7 +24,7 @@ func TestAddCmd(t *testing.T) {
 	t.Run("repo already exists", func(t *testing.T) {
 		cmd := NewAddCmd(f)
 		cmd.SetArgs([]string{"default", "../../testdata/repos/repo2"})
-		cmd.SetOut(ioutil.Discard)
+		cmd.SetOut(io.Discard)
 
 		err := cmd.Execute()
 		require.EqualError(t, err, `repository "default" already exists`)
@@ -37,7 +37,7 @@ func TestAddCmd(t *testing.T) {
 	t.Run("invalid repository url", func(t *testing.T) {
 		cmd := NewAddCmd(f)
 		cmd.SetArgs([]string{"new-repo", "invalid\\:"})
-		cmd.SetOut(ioutil.Discard)
+		cmd.SetOut(io.Discard)
 
 		err := cmd.Execute()
 		require.EqualError(t, err, `invalid repo URL "invalid\\:": parse "invalid\\:": first path segment in URL cannot contain colon`)
@@ -50,7 +50,7 @@ func TestAddCmd(t *testing.T) {
 	t.Run("add new repo", func(t *testing.T) {
 		cmd := NewAddCmd(f)
 		cmd.SetArgs([]string{"new-repo", "../../testdata/repos/repo2"})
-		cmd.SetOut(ioutil.Discard)
+		cmd.SetOut(io.Discard)
 
 		require.NoError(t, cmd.Execute())
 

--- a/internal/cmd/repository/create_test.go
+++ b/internal/cmd/repository/create_test.go
@@ -1,7 +1,7 @@
 package repository
 
 import (
-	"io/ioutil"
+	"io"
 	"path/filepath"
 	"testing"
 
@@ -25,7 +25,7 @@ func TestCreateCmd(t *testing.T) {
 
 		cmd := NewCreateCmd(f)
 		cmd.SetArgs([]string{"default", dir})
-		cmd.SetOut(ioutil.Discard)
+		cmd.SetOut(io.Discard)
 
 		require.Error(t, cmd.Execute())
 		require.NoDirExists(t, dir)
@@ -36,7 +36,7 @@ func TestCreateCmd(t *testing.T) {
 
 		cmd := NewCreateCmd(f)
 		cmd.SetArgs([]string{"new-repo", dir})
-		cmd.SetOut(ioutil.Discard)
+		cmd.SetOut(io.Discard)
 
 		require.NoError(t, cmd.Execute())
 		require.DirExists(t, dir)
@@ -45,7 +45,7 @@ func TestCreateCmd(t *testing.T) {
 	t.Run("creating remote skeletons is not supported", func(t *testing.T) {
 		cmd := NewCreateCmd(f)
 		cmd.SetArgs([]string{"remote-repo", "https://foo.bar.baz/owner/repo"})
-		cmd.SetOut(ioutil.Discard)
+		cmd.SetOut(io.Discard)
 
 		require.Error(t, cmd.Execute())
 	})

--- a/internal/cmd/repository/list_test.go
+++ b/internal/cmd/repository/list_test.go
@@ -1,7 +1,7 @@
 package repository
 
 import (
-	"io/ioutil"
+	"io"
 	"testing"
 
 	"github.com/martinohmann/kickoff/internal/cli"
@@ -25,7 +25,7 @@ func TestListCmd(t *testing.T) {
 		out.Reset()
 
 		cmd := NewListCmd(f)
-		cmd.SetOut(ioutil.Discard)
+		cmd.SetOut(io.Discard)
 
 		require.NoError(t, cmd.Execute())
 
@@ -39,7 +39,7 @@ func TestListCmd(t *testing.T) {
 
 		cmd := NewListCmd(f)
 		cmd.SetArgs([]string{"-o", "wide"})
-		cmd.SetOut(ioutil.Discard)
+		cmd.SetOut(io.Discard)
 
 		require.NoError(t, cmd.Execute())
 
@@ -53,7 +53,7 @@ func TestListCmd(t *testing.T) {
 
 		cmd := NewListCmd(f)
 		cmd.SetArgs([]string{"-o", "name"})
-		cmd.SetOut(ioutil.Discard)
+		cmd.SetOut(io.Discard)
 
 		require.NoError(t, cmd.Execute())
 

--- a/internal/cmd/repository/remove_test.go
+++ b/internal/cmd/repository/remove_test.go
@@ -1,7 +1,7 @@
 package repository
 
 import (
-	"io/ioutil"
+	"io"
 	"testing"
 
 	"github.com/martinohmann/kickoff/internal/cli"
@@ -25,7 +25,7 @@ func TestRemoveCmd(t *testing.T) {
 	t.Run("repo not exists", func(t *testing.T) {
 		cmd := NewRemoveCmd(f)
 		cmd.SetArgs([]string{"non-existent"})
-		cmd.SetOut(ioutil.Discard)
+		cmd.SetOut(io.Discard)
 
 		err := cmd.Execute()
 		require.EqualError(t, err, `repository "non-existent" not configured`)
@@ -38,7 +38,7 @@ func TestRemoveCmd(t *testing.T) {
 	t.Run("remove a repo", func(t *testing.T) {
 		cmd := NewRemoveCmd(f)
 		cmd.SetArgs([]string{"other"})
-		cmd.SetOut(ioutil.Discard)
+		cmd.SetOut(io.Discard)
 
 		require.NoError(t, cmd.Execute())
 

--- a/internal/cmd/skeleton/create_test.go
+++ b/internal/cmd/skeleton/create_test.go
@@ -1,7 +1,7 @@
 package skeleton
 
 import (
-	"io/ioutil"
+	"io"
 	"path/filepath"
 	"testing"
 
@@ -37,7 +37,7 @@ func TestCreateCmd(t *testing.T) {
 	t.Run("repository does not exist", func(t *testing.T) {
 		cmd := NewCreateCmd(f)
 		cmd.SetArgs([]string{"nonexistent", "default"})
-		cmd.SetOut(ioutil.Discard)
+		cmd.SetOut(io.Discard)
 
 		err := cmd.Execute()
 		assert.EqualError(t, err, `repository "nonexistent" not configured`)
@@ -47,7 +47,7 @@ func TestCreateCmd(t *testing.T) {
 	t.Run("remote repo", func(t *testing.T) {
 		cmd := NewCreateCmd(f)
 		cmd.SetArgs([]string{"remote", "default"})
-		cmd.SetOut(ioutil.Discard)
+		cmd.SetOut(io.Discard)
 
 		err := cmd.Execute()
 		assert.EqualError(t, err, `creating skeletons in remote repositories is not supported`)
@@ -57,7 +57,7 @@ func TestCreateCmd(t *testing.T) {
 	t.Run("skeleton already exists", func(t *testing.T) {
 		cmd := NewCreateCmd(f)
 		cmd.SetArgs([]string{"default", "default"})
-		cmd.SetOut(ioutil.Discard)
+		cmd.SetOut(io.Discard)
 
 		err := cmd.Execute()
 		assert.EqualError(t, err, `skeleton "default" already exists in repository "default"`)
@@ -67,7 +67,7 @@ func TestCreateCmd(t *testing.T) {
 	t.Run("skeleton can be created", func(t *testing.T) {
 		cmd := NewCreateCmd(f)
 		cmd.SetArgs([]string{"default", "myskel"})
-		cmd.SetOut(ioutil.Discard)
+		cmd.SetOut(io.Discard)
 
 		err := cmd.Execute()
 		require.NoError(t, err)

--- a/internal/cmd/skeleton/list_test.go
+++ b/internal/cmd/skeleton/list_test.go
@@ -1,7 +1,7 @@
 package skeleton
 
 import (
-	"io/ioutil"
+	"io"
 	"testing"
 
 	"github.com/martinohmann/kickoff/internal/cli"
@@ -24,7 +24,7 @@ func TestListCmd(t *testing.T) {
 		out.Reset()
 
 		cmd := NewListCmd(f)
-		cmd.SetOut(ioutil.Discard)
+		cmd.SetOut(io.Discard)
 
 		require.NoError(t, cmd.Execute())
 
@@ -37,7 +37,7 @@ func TestListCmd(t *testing.T) {
 
 		cmd := NewListCmd(f)
 		cmd.SetArgs([]string{"-o", "wide"})
-		cmd.SetOut(ioutil.Discard)
+		cmd.SetOut(io.Discard)
 
 		require.NoError(t, cmd.Execute())
 
@@ -50,7 +50,7 @@ func TestListCmd(t *testing.T) {
 
 		cmd := NewListCmd(f)
 		cmd.SetArgs([]string{"-o", "name"})
-		cmd.SetOut(ioutil.Discard)
+		cmd.SetOut(io.Discard)
 
 		require.NoError(t, cmd.Execute())
 

--- a/internal/cmd/skeleton/show_test.go
+++ b/internal/cmd/skeleton/show_test.go
@@ -2,7 +2,7 @@ package skeleton
 
 import (
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"os"
 	"testing"
 
@@ -25,7 +25,7 @@ func TestShowCmd(t *testing.T) {
 	t.Run("nonexistent repository", func(t *testing.T) {
 		cmd := NewShowCmd(f)
 		cmd.SetArgs([]string{"myskeleton", "-r", "nonexistent"})
-		cmd.SetOut(ioutil.Discard)
+		cmd.SetOut(io.Discard)
 
 		assert.Error(t, cmd.Execute())
 	})
@@ -33,7 +33,7 @@ func TestShowCmd(t *testing.T) {
 	t.Run("nonexistent skeleton", func(t *testing.T) {
 		cmd := NewShowCmd(f)
 		cmd.SetArgs([]string{"nonexistent"})
-		cmd.SetOut(ioutil.Discard)
+		cmd.SetOut(io.Discard)
 
 		require.Error(t, cmd.Execute())
 	})
@@ -43,7 +43,7 @@ func TestShowCmd(t *testing.T) {
 
 		cmd := NewShowCmd(f)
 		cmd.SetArgs([]string{"minimal"})
-		cmd.SetOut(ioutil.Discard)
+		cmd.SetOut(io.Discard)
 
 		require.NoError(t, cmd.Execute())
 
@@ -60,7 +60,7 @@ func TestShowCmd(t *testing.T) {
 
 		cmd := NewShowCmd(f)
 		cmd.SetArgs([]string{"minimal", "-o", "yaml"})
-		cmd.SetOut(ioutil.Discard)
+		cmd.SetOut(io.Discard)
 
 		require.NoError(t, cmd.Execute())
 
@@ -72,7 +72,7 @@ func TestShowCmd(t *testing.T) {
 
 		cmd := NewShowCmd(f)
 		cmd.SetArgs([]string{"minimal", "-o", "json"})
-		cmd.SetOut(ioutil.Discard)
+		cmd.SetOut(io.Discard)
 
 		require.NoError(t, cmd.Execute())
 
@@ -89,7 +89,7 @@ func TestShowCmd(t *testing.T) {
 
 		cmd := NewShowCmd(f)
 		cmd.SetArgs([]string{"advanced", "README.md.skel"})
-		cmd.SetOut(ioutil.Discard)
+		cmd.SetOut(io.Discard)
 
 		require.NoError(t, cmd.Execute())
 
@@ -101,7 +101,7 @@ func TestShowCmd(t *testing.T) {
 
 		cmd := NewShowCmd(f)
 		cmd.SetArgs([]string{"advanced", "README.md.skel", "-o", "json"})
-		cmd.SetOut(ioutil.Discard)
+		cmd.SetOut(io.Discard)
 
 		require.NoError(t, cmd.Execute())
 
@@ -118,7 +118,7 @@ func TestShowCmd(t *testing.T) {
 
 		cmd := NewShowCmd(f)
 		cmd.SetArgs([]string{"advanced", "README.md.skel", "-o", "yaml"})
-		cmd.SetOut(ioutil.Discard)
+		cmd.SetOut(io.Discard)
 
 		require.NoError(t, cmd.Execute())
 
@@ -133,7 +133,7 @@ func TestShowCmd(t *testing.T) {
 	t.Run("nonexistent file", func(t *testing.T) {
 		cmd := NewShowCmd(f)
 		cmd.SetArgs([]string{"advanced", "nonexistent-file"})
-		cmd.SetOut(ioutil.Discard)
+		cmd.SetOut(io.Discard)
 
 		err := cmd.Execute()
 		require.EqualError(t, err, os.ErrNotExist.Error())
@@ -144,7 +144,7 @@ func TestShowCmd(t *testing.T) {
 
 		cmd := NewShowCmd(f)
 		cmd.SetArgs([]string{"advanced", "{{.Values.filename}}"})
-		cmd.SetOut(ioutil.Discard)
+		cmd.SetOut(io.Discard)
 
 		err := cmd.Execute()
 		require.EqualError(t, err, `{{.Values.filename}} is a directory`)

--- a/internal/kickoff/config.go
+++ b/internal/kickoff/config.go
@@ -2,7 +2,6 @@ package kickoff
 
 import (
 	"fmt"
-	"io/ioutil"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -153,7 +152,7 @@ func SaveConfig(path string, config *Config) error {
 func Load(path string, v interface{}) error {
 	log.WithField("path", path).Debug("loading file")
 
-	buf, err := ioutil.ReadFile(path)
+	buf, err := os.ReadFile(path)
 	if err != nil {
 		return err
 	}
@@ -175,7 +174,7 @@ func Save(path string, v interface{}) error {
 		return err
 	}
 
-	return ioutil.WriteFile(path, buf, 0644)
+	return os.WriteFile(path, buf, 0644)
 }
 
 func detectDefaultProjectOwner() string {

--- a/internal/project/plan.go
+++ b/internal/project/plan.go
@@ -2,7 +2,6 @@ package project
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"sort"
@@ -194,7 +193,7 @@ func (p *Plan) executeOperation(op *Operation) error {
 		content = []byte(rendered)
 	}
 
-	return ioutil.WriteFile(dest.AbsPath(), content, source.Mode)
+	return os.WriteFile(dest.AbsPath(), content, source.Mode)
 }
 
 func (p *Plan) makeTemplateValues(config *Config, skeleton *kickoff.Skeleton) error {

--- a/internal/project/plan_test.go
+++ b/internal/project/plan_test.go
@@ -3,7 +3,6 @@ package project
 import (
 	"context"
 	"errors"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -168,16 +167,13 @@ func TestCreate(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
+			tmpdir := t.TempDir()
+
 			repo, err := repository.Open(context.Background(), "../testdata/repos/repo1", nil)
 			require.NoError(t, err)
 
 			skeleton, err := repo.LoadSkeleton("advanced")
 			require.NoError(t, err)
-
-			tmpdir, err := ioutil.TempDir("", "kickoff-")
-			require.NoError(t, err)
-
-			defer os.RemoveAll(tmpdir)
 
 			tester := &dirTester{T: t, dir: tmpdir}
 
@@ -213,13 +209,13 @@ func (t *dirTester) path(file string) string {
 }
 
 func (t *dirTester) assertFileContains(file, expectedContent string) {
-	contents, err := ioutil.ReadFile(t.path(file))
+	contents, err := os.ReadFile(t.path(file))
 	require.NoError(t, err)
 	assert.Equal(t, expectedContent, string(contents))
 }
 
 func (t *dirTester) assertFileNotContains(file, expectedContent string) {
-	contents, err := ioutil.ReadFile(t.path(file))
+	contents, err := os.ReadFile(t.path(file))
 	require.NoError(t, err)
 	assert.NotEqual(t, expectedContent, string(contents))
 }
@@ -229,7 +225,7 @@ func (t *dirTester) assertFileExists(file string) {
 }
 
 func (t *dirTester) assertFileAbsent(file string) {
-	_, err := ioutil.ReadFile(t.path(file))
+	_, err := os.ReadFile(t.path(file))
 	assert.True(t, os.IsNotExist(err))
 }
 
@@ -239,6 +235,6 @@ func (t *dirTester) mustWriteFile(file, content string) {
 	err := os.MkdirAll(filepath.Dir(path), 0777)
 	require.NoError(t, err)
 
-	err = ioutil.WriteFile(path, []byte(content), 0644)
+	err = os.WriteFile(path, []byte(content), 0644)
 	require.NoError(t, err)
 }

--- a/internal/repository/create.go
+++ b/internal/repository/create.go
@@ -3,7 +3,6 @@ package repository
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"sort"
@@ -77,8 +76,7 @@ func writeFiles(dir string) error {
 
 		log.WithField("path", path).Debug("creating skeleton file")
 
-		err := ioutil.WriteFile(path, []byte(contents), 0644)
-		if err != nil {
+		if err := os.WriteFile(path, []byte(contents), 0644); err != nil {
 			return fmt.Errorf("failed to write skeleton file: %w", err)
 		}
 	}

--- a/internal/repository/repo.go
+++ b/internal/repository/repo.go
@@ -3,7 +3,6 @@ package repository
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -121,7 +120,7 @@ func (r *repository) CreateSkeleton(name string) (*kickoff.SkeletonRef, error) {
 func listSkeletons(repoRef *kickoff.RepoRef, dir string) ([]*kickoff.SkeletonRef, error) {
 	refs := make([]*kickoff.SkeletonRef, 0)
 
-	fileInfos, err := ioutil.ReadDir(dir)
+	fileInfos, err := os.ReadDir(dir)
 	if err != nil {
 		return nil, err
 	}
@@ -265,7 +264,7 @@ func loadSkeletonFiles(ref *kickoff.SkeletonRef) ([]*kickoff.BufferedFile, error
 			return fmt.Errorf("file %s too large: refusing to load files larger than 100 MiB", absPath)
 		}
 
-		buf, err := ioutil.ReadFile(absPath)
+		buf, err := os.ReadFile(absPath)
 		if err != nil {
 			return err
 		}

--- a/internal/template/render.go
+++ b/internal/template/render.go
@@ -6,7 +6,6 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"text/template"
 
 	"github.com/Masterminds/sprig/v3"
@@ -24,7 +23,7 @@ func Render(templateText string, data interface{}) (string, error) {
 
 // RenderReader renders a template obtained from a reader with data.
 func RenderReader(r io.Reader, data interface{}) (string, error) {
-	buf, err := ioutil.ReadAll(r)
+	buf, err := io.ReadAll(r)
 	if err != nil {
 		return "", err
 	}

--- a/internal/template/values.go
+++ b/internal/template/values.go
@@ -1,7 +1,7 @@
 package template
 
 import (
-	"io/ioutil"
+	"os"
 
 	"github.com/ghodss/yaml"
 	"github.com/imdario/mergo"
@@ -35,7 +35,7 @@ func MergeValues(values ...Values) (Values, error) {
 func LoadValues(path string) (Values, error) {
 	var values Values
 
-	buf, err := ioutil.ReadFile(path)
+	buf, err := os.ReadFile(path)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
No need to support multiple go versions.

Also removes usages of the deprecated `io/ioutil` package.