### PR TITLE
revert: "feat!: remove gitignore and license defaults"

### DIFF
--- a/internal/cmd/init.go
+++ b/internal/cmd/init.go
@@ -1,17 +1,23 @@
 package cmd
 
 import (
+	"context"
 	"fmt"
+	"net/http"
 	"os"
+	"strings"
 
 	survey "github.com/AlecAivazis/survey/v2"
 	"github.com/fatih/color"
 	"github.com/martinohmann/kickoff/internal/cli"
 	"github.com/martinohmann/kickoff/internal/cmdutil"
+	"github.com/martinohmann/kickoff/internal/gitignore"
 	"github.com/martinohmann/kickoff/internal/homedir"
 	"github.com/martinohmann/kickoff/internal/kickoff"
+	"github.com/martinohmann/kickoff/internal/license"
 	"github.com/martinohmann/kickoff/internal/prompt"
 	"github.com/martinohmann/kickoff/internal/repository"
+	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
 
@@ -24,6 +30,7 @@ func NewInitCmd(f *cmdutil.Factory) *cobra.Command {
 		IOStreams:  f.IOStreams,
 		Config:     f.Config,
 		ConfigPath: f.ConfigPath,
+		HTTPClient: f.HTTPClient,
 		Prompt:     f.Prompt,
 	}
 
@@ -46,8 +53,9 @@ func NewInitCmd(f *cmdutil.Factory) *cobra.Command {
 type InitOptions struct {
 	cli.IOStreams
 
-	Config func() (*kickoff.Config, error)
-	Prompt prompt.Prompt
+	Config     func() (*kickoff.Config, error)
+	HTTPClient func() *http.Client
+	Prompt     prompt.Prompt
 
 	ConfigPath string
 }
@@ -61,6 +69,8 @@ func (o *InitOptions) Run() error {
 
 	configureFuncs := []func(*kickoff.Config) error{
 		o.configureProject,
+		o.configureLicense,
+		o.configureGitignoreTemplates,
 		o.configureDefaultSkeletonRepository,
 		o.persistConfiguration,
 	}
@@ -101,6 +111,132 @@ func (o *InitOptions) configureProject(config *kickoff.Config) error {
             can override this on project creation. 
             The project owner is automatically inserted into license texts if enabled.`),
 	}, &config.Project.Owner)
+}
+
+func (o *InitOptions) configureLicense(config *kickoff.Config) error {
+	client := license.NewClient(o.HTTPClient())
+
+	licenses, err := client.ListLicenses(context.Background())
+	if err != nil {
+		log.WithError(err).
+			Debug("failed to fetch licenses, skipping configuration")
+		return nil
+	}
+
+	if len(licenses) == 0 {
+		return nil
+	}
+
+	licenseOptions := make([]string, 0, len(licenses))
+	licenseMap := make(map[string]string, len(licenses))
+
+	for _, license := range licenses {
+		licenseOptions = append(licenseOptions, license.Name)
+		licenseMap[license.Name] = license.Key
+	}
+
+	var chooseLicense bool
+
+	err = o.Prompt.AskOne(&survey.Confirm{
+		Message: "Do you want to set a default project license?",
+		Default: false,
+		Help: cmdutil.LongDesc(`
+			Open source license
+
+			You can set a default open source license that will be used for all new projects
+			if not explicitly overridden on project creation.
+		`),
+	}, &chooseLicense)
+	if err != nil {
+		return err
+	}
+
+	if !chooseLicense {
+		config.Project.License = ""
+		return nil
+	}
+
+	var chosenLicense string
+
+	err = o.Prompt.AskOne(&survey.Select{
+		Message:  "Choose a license",
+		Options:  licenseOptions,
+		PageSize: 20,
+		VimMode:  true,
+		Help: cmdutil.LongDesc(`
+			Open source license
+
+			You can set a default open source license that will be used for all new projects
+			if not explicitly overridden on project creation.
+		`),
+	}, &chosenLicense)
+	if err != nil {
+		return err
+	}
+
+	config.Project.License = licenseMap[chosenLicense]
+
+	return nil
+}
+
+func (o *InitOptions) configureGitignoreTemplates(config *kickoff.Config) error {
+	client := gitignore.NewClient(o.HTTPClient())
+
+	gitignoreOptions, err := client.ListTemplates(context.Background())
+	if err != nil {
+		log.WithError(err).
+			Debug("failed to fetch gitignore templates, skipping configuration")
+		return nil
+	}
+
+	if len(gitignoreOptions) == 0 {
+		return nil
+	}
+
+	var selectGitignores bool
+
+	err = o.Prompt.AskOne(&survey.Confirm{
+		Message: "Do you want to select default .gitignore templates?",
+		Default: false,
+		Help: cmdutil.LongDesc(`
+			Gitignore templates
+
+			If .gitignore templates are configured, new projects will automatically
+			include a .gitignore which is populated with the specified templates.
+			Don't worry, you can override this setting on project creation if you want to.
+		`),
+	}, &selectGitignores)
+	if err != nil {
+		return err
+	}
+
+	if !selectGitignores {
+		config.Project.Gitignore = ""
+		return nil
+	}
+
+	var selectedGitignores []string
+
+	err = o.Prompt.AskOne(&survey.MultiSelect{
+		Message:  "Choose gitignore templates",
+		Options:  gitignoreOptions,
+		PageSize: 20,
+		VimMode:  true,
+		Help: cmdutil.LongDesc(`
+			Gitignore templates
+
+			If .gitignore templates are configured, new projects will automatically
+			include a .gitignore which is populated with the specified templates.
+			Don't worry, you can override this setting on project creation if you want to.
+		`),
+	}, &selectedGitignores)
+	if err != nil {
+		return err
+	}
+
+	config.Project.Gitignore = strings.Join(selectedGitignores, ",")
+
+	return nil
 }
 
 func (o *InitOptions) configureDefaultSkeletonRepository(config *kickoff.Config) error {

--- a/internal/cmd/project/create_interactive.go
+++ b/internal/cmd/project/create_interactive.go
@@ -192,7 +192,7 @@ func (o *CreateOptions) configureLicense(config *kickoff.Config) error {
 }
 
 func (o *CreateOptions) configureGitignoreTemplates(config *kickoff.Config) error {
-	if len(o.Gitignores) > 0 {
+	if len(o.gitignores) > 0 {
 		return nil
 	}
 
@@ -203,7 +203,7 @@ func (o *CreateOptions) configureGitignoreTemplates(config *kickoff.Config) erro
 		return err
 	}
 
-	return o.Prompt.AskOne(&survey.MultiSelect{
+	err = o.Prompt.AskOne(&survey.MultiSelect{
 		Message:  "Choose gitignore templates",
 		Options:  options,
 		PageSize: 20,
@@ -214,7 +214,13 @@ func (o *CreateOptions) configureGitignoreTemplates(config *kickoff.Config) erro
             If .gitignore templates are configured, new projects will
             automatically include a .gitignore which is populated with the
             specified templates.`),
-	}, &o.Gitignores)
+	}, &o.gitignores)
+	if err != nil {
+		return err
+	}
+
+	o.Gitignore = strings.Join(o.gitignores, ",")
+	return nil
 }
 
 func (o *CreateOptions) configureGit(config *kickoff.Config) error {

--- a/internal/kickoff/config.go
+++ b/internal/kickoff/config.go
@@ -83,6 +83,11 @@ type ProjectConfig struct {
 	Host string `json:"host,omitempty"`
 	// Owner holds the default repository owner name.
 	Owner string `json:"owner,omitempty"`
+	// License holds the name of the default open source license.
+	License string `json:"license,omitempty"`
+	// Gitignore holds a comma-separated list of gitignore templates, e.g.
+	// 'go,hugo'.
+	Gitignore string `json:"gitignore,omitempty"`
 }
 
 // ApplyDefaults applies defaults to unset fields. If the Owner field is empty
@@ -95,6 +100,14 @@ func (p *ProjectConfig) ApplyDefaults() {
 
 	if p.Owner == "" {
 		p.Owner = detectDefaultProjectOwner()
+	}
+
+	if p.License == NoLicense {
+		p.License = ""
+	}
+
+	if p.Gitignore == NoGitignore {
+		p.Gitignore = ""
 	}
 }
 

--- a/internal/kickoff/config_test.go
+++ b/internal/kickoff/config_test.go
@@ -15,7 +15,9 @@ import (
 func TestConfig_ApplyDefaults(t *testing.T) {
 	config := Config{
 		Project: ProjectConfig{
-			Owner: "johndoe",
+			Owner:     "johndoe",
+			License:   NoLicense,
+			Gitignore: NoGitignore,
 		},
 	}
 

--- a/internal/kickoff/kickoff.go
+++ b/internal/kickoff/kickoff.go
@@ -35,6 +35,15 @@ const (
 )
 
 const (
+	// NoLicense means that no license file will be generated for a new
+	// project.
+	NoLicense = "none"
+	// NoGitignore means that no .gitignore file will be generated for a new
+	// project.
+	NoGitignore = "none"
+)
+
+const (
 	// EnvKeyLogLevel configures custom path to the kickoff config file.
 	EnvKeyConfig = "KICKOFF_CONFIG"
 	// EnvKeyEditor configures the command used to edit config files.


### PR DESCRIPTION
Reverts martinohmann/kickoff#137

I guess it makes sense to keep this functionality, but it should be adjusted (e.g. remove the `none` weirdness and improve `kickoff init` experience).