### PR TITLE
fix: make relative local repo paths absolute

### DIFF
--- a/internal/cmd/init.go
+++ b/internal/cmd/init.go
@@ -225,6 +225,11 @@ func (o *InitOptions) configureDefaultSkeletonRepository(config *kickoff.Config)
 		return err
 	}
 
+	if ref.IsLocal() {
+		// ensure local path is absolute
+		repoURL = ref.LocalPath()
+	}
+
 	config.Repositories[kickoff.DefaultRepositoryName] = repoURL
 
 	if ref.IsRemote() {

--- a/internal/cmd/repository/add.go
+++ b/internal/cmd/repository/add.go
@@ -80,7 +80,10 @@ func (o *AddOptions) Run() error {
 		return err
 	}
 
-	if ref.IsRemote() && o.Revision != "" {
+	if ref.IsLocal() {
+		// ensure local path is absolute
+		o.RepoURL = ref.LocalPath()
+	} else if o.Revision != "" {
 		ref.Revision = o.Revision
 
 		o.RepoURL = ref.String()

--- a/internal/cmd/repository/add_test.go
+++ b/internal/cmd/repository/add_test.go
@@ -2,6 +2,7 @@ package repository
 
 import (
 	"io"
+	"path/filepath"
 	"testing"
 
 	"github.com/martinohmann/kickoff/internal/cli"
@@ -47,16 +48,19 @@ func TestAddCmd(t *testing.T) {
 		assert.Equal(t, "../../testdata/repos/repo1", config.Repositories["default"])
 	})
 
-	t.Run("add new repo", func(t *testing.T) {
+	t.Run("adds new repo, resolves with abspath", func(t *testing.T) {
 		cmd := NewAddCmd(f)
 		cmd.SetArgs([]string{"new-repo", "../../testdata/repos/repo2"})
 		cmd.SetOut(io.Discard)
+
+		absPath, err := filepath.Abs("../../testdata/repos/repo2")
+		require.NoError(t, err)
 
 		require.NoError(t, cmd.Execute())
 
 		config, err := kickoff.LoadConfig(configPath)
 		require.NoError(t, err)
 		assert.Len(t, config.Repositories, 2)
-		assert.Equal(t, "../../testdata/repos/repo2", config.Repositories["new-repo"])
+		assert.Equal(t, absPath, config.Repositories["new-repo"])
 	})
 }

--- a/internal/cmd/repository/create.go
+++ b/internal/cmd/repository/create.go
@@ -3,10 +3,12 @@ package repository
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 
 	"github.com/fatih/color"
 	"github.com/martinohmann/kickoff/internal/cli"
 	"github.com/martinohmann/kickoff/internal/cmdutil"
+	"github.com/martinohmann/kickoff/internal/homedir"
 	"github.com/martinohmann/kickoff/internal/kickoff"
 	"github.com/martinohmann/kickoff/internal/repository"
 	log "github.com/sirupsen/logrus"
@@ -39,7 +41,7 @@ func NewCreateCmd(f *cmdutil.Factory) *cobra.Command {
 			}
 			return nil, cobra.ShellCompDirectiveFilterDirs
 		},
-		RunE: func(cmd *cobra.Command, args []string) (err error) {
+		RunE: func(cmd *cobra.Command, args []string) error {
 			o.RepoName = args[0]
 			o.RepoDir = args[1]
 
@@ -92,6 +94,12 @@ func (o *CreateOptions) Run() error {
 		return err
 	}
 
+	// ensure local path is absolute
+	o.RepoDir, err = filepath.Abs(o.RepoDir)
+	if err != nil {
+		return err
+	}
+
 	config.Repositories[o.RepoName] = o.RepoDir
 
 	err = kickoff.SaveConfig(o.ConfigPath, config)
@@ -99,7 +107,7 @@ func (o *CreateOptions) Run() error {
 		return err
 	}
 
-	fmt.Fprintf(o.Out, "%s Created new skeleton repository in %s\n\n", color.GreenString("✓"), bold.Sprint(o.RepoDir))
+	fmt.Fprintf(o.Out, "%s Created new skeleton repository in %s\n\n", color.GreenString("✓"), bold.Sprint(homedir.Collapse(o.RepoDir)))
 	fmt.Fprintln(o.Out, "You can inspect it by running:", bold.Sprintf("kickoff skeleton list -r %s", o.RepoName))
 
 	return nil


### PR DESCRIPTION
When the user add or creates a new local repository with a relative path
it is now made absolute before adding it to the config.

Fixes https://github.com/martinohmann/kickoff/issues/148